### PR TITLE
feat: Core submitter (non-UI) host for lower-level Deadline Cloud UI, job bundle creation, piping render parameters.

### DIFF
--- a/src/deadline/vred_submitter/__init__.py
+++ b/src/deadline/vred_submitter/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/src/deadline/vred_submitter/constants.py
+++ b/src/deadline/vred_submitter/constants.py
@@ -1,0 +1,116 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Provides a Constants class that focuses on the backend submitter component"""
+
+from typing import List, Final
+
+
+class ConstantsMeta(type):
+    """Metaclass to prevent modification of class attributes."""
+
+    def __setattr__(cls, name, value):
+        """Prevent modification of class attributes."""
+        raise AttributeError(f"Cannot modify constant '{name}'")
+
+    def __delattr__(cls, name):
+        """Prevent deletion of class attributes."""
+        raise AttributeError(f"Cannot delete constant '{name}'")
+
+
+class Constants(metaclass=ConstantsMeta):
+    """Constants class for backend submitter component"""
+
+    ANIMATION_SETTINGS_DIALOG_NAME: Final[str] = "Animation Settings"
+    ASSET_REFERENCES_FILENAME: Final[str] = "asset_references.yaml"
+    BASE_TEN: Final[int] = 10
+    COMBO_BOX_MIN_WIDTH: Final[int] = 100
+    COMBO_BOX_PADDING: Final[int] = 60
+    CONDA_PACKAGES_FIELD: Final[str] = "CondaPackages"
+    CUSTOM_SPEED_FIELD_NAME: Final[str] = "_customSpeed"
+    DEADLINE_CLOUD_FOR_VRED_PACKAGE_PREFIX: Final[str] = "deadline_cloud_for_vred"
+    DEADLINE_CLOUD_FOR_VRED_SUBMITTER_VERSION_FIELD: Final[str] = (
+        "deadline-cloud-for-vred-submitter-version"
+    )
+    DEADLINE_CLOUD_MENU_NAME: Final[str] = "Deadline Cloud"
+    DEFAULT_FIELD: Final[str] = "default"
+    DEFAULT_JOB_TEMPLATE_FILENAME: Final[str] = "default_vred_job_template.yaml"
+    DEFAULT_SCENE_FILE_FPS_COUNT: Final[float] = 24.0
+    DESCRIPTION_FIELD: Final[str] = "description"
+    ELLIPSIS_LABEL: Final[str] = "..."
+    ENVIRONMENT_FIELD: Final[str] = "environment"
+    ERROR_ANIMATION_SETTINGS_DIALOG_NOT_FOUND: Final[str] = "Animation settings dialog not found"
+    ERROR_FILE_PERMISSIONS_ISSUE: Final[str] = "Permission denied accessing file"
+    ERROR_FRAME_RANGE_FORMAT: Final[str] = "Invalid frame range format"
+    ERROR_PREFERENCES_BUTTON_NOT_FOUND: Final[str] = "Preferences button not found"
+    ERROR_QUEUE_PARAM_CONFLICT: Final[str] = (
+        "The following queue parameters conflict with the VRED job parameters:\n"
+    )
+    ERROR_SPEED_SETTINGS_WIDGET_NOT_FOUND: Final[str] = "Speed widget not found"
+    ERROR_TIMELINE_ACTION_NOT_FOUND: Final[str] = "Timeline action not found"
+    ERROR_TIMELINE_TOOLBAR_NOT_FOUND: Final[str] = "Timeline toolbar not found"
+    ERROR_YAML_GENERAL_ERROR: Final[str] = "Unexpected error reading YAML file"
+    ERROR_YAML_INVALID_FORMAT: Final[str] = "Invalid YAML format in"
+    ERROR_YAML_OBJECT_NOT_FOUND: Final[str] = "YAML file must contain a dictionary/object, got"
+    ERROR_YAML_NOT_FOUND: Final[str] = "YAML file not found"
+    FRAME_RANGE_REGEX: Final[str] = r"^(-?\d+)-(-?\d+)(?:x(\d+))?$"
+    FRAME_START_STOP_DELIMITER: Final[str] = "-"
+    HOST_REQUIREMENTS_FIELD: Final[str] = "hostRequirements"
+    JOB_ENVIRONMENTS_FIELD: Final[str] = "jobEnvironments"
+    MESSAGE_BOX_MIN_WIDTH: Final[int] = 300
+    MESSAGE_BOX_SPACER_PREFERRED_WIDTH: Final[int] = 400
+    MESSAGE_BOX_MAX_WIDTH: Final[int] = 800
+    MINIMUM_WINDOW_SIZE: Final[List[int]] = [1500, 1500]
+    NAME_FIELD: Final[str] = "name"
+    NAN: Final[str] = "NaN"
+    NEGATIVE_INFINITY: Final[str] = "-inf"
+    PARAMETER_DEFINITIONS_FIELD: Final[str] = "parameterDefinitions"
+    PARAMETER_VALUES_FIELD: Final[str] = "parameterValues"
+    PARAMETER_VALUES_FILENAME: Final[str] = "parameter_values.yaml"
+    POSITIVE_INFINITY: Final[str] = "inf"
+    PUSH_BUTTON_MAXIMUM_WIDTH: Final[int] = 100
+    PUSH_BUTTON_MAXIMUM_HEIGHT: Final[int] = 40
+    PUSH_BUTTON_PADDING_PIXELS: Final[int] = 20
+    PUSH_BUTTON_WIDTH_FACTOR: Final[int] = 4
+    QT_GROUP_BOX_STYLESHEET: Final[
+        str
+    ] = """
+            QGroupBox {
+                border: 4px solid #999999;
+                border-radius: 10px;
+                margin-top: 5ex;
+                font-weight: bold;
+                color: #ffffff;
+            }
+            QGroupBox::title {
+                subcontrol-origin: margin;
+                subcontrol-position: top left;
+                padding: 0 10px;
+                background-color: #444444;
+            }
+    """
+    READ_FLAG: Final[str] = "r"
+    SCENE_FILE_NOT_SAVED_TITLE: Final[str] = "Warning: scene file not saved"
+    SCENE_FILE_NOT_SAVED_BODY: Final[str] = (
+        "The scene file has unsaved local changes that will not be included in the job "
+        "submission.\n\nDo you want to save the scene file before submitting?"
+    )
+    SELECT_DIRECTORY_PROMPT: Final[str] = "Select Directory"
+    SELECT_FILE_PROMPT: Final[str] = "Select File"
+    SUBMIT_TO_DEADLINE_CLOUD_ACTION_NAME: Final[str] = "Submit To Deadline Cloud"
+    STEPS_FIELD: Final[str] = "steps"
+    TEMPLATE_FILENAME: Final[str] = "template.yaml"
+    TIMELINE_ACTION_NAME: Final[str] = "Timeline"
+    TIMELINE_ANIMATION_PREFS_BUTTON_NAME: Final[str] = "_prefs"
+    TIMELINE_TOOLBAR_NAME: Final[str] = "Timeline_Toolbar"
+    UTF8_FLAG: Final[str] = "utf-8"
+    VALUE_FIELD: Final[str] = "value"
+    VERY_LONG_TEXT_ENTRY_WIDTH: Final[int] = 700
+    VRED_PRODUCT_NAME: Final[str] = "VRED"
+    VRED_RENDER_SCRIPT_FILENAME: Final[str] = "VRED_RenderScript_DeadlineCloud.py"
+    VRED_VERSION_FIELD: Final[str] = "vred-version"
+    WORKER_SUBFOLDER_NAME = "worker"
+    WRITE_FLAG: Final[str] = "w"
+
+    def __new__(cls):
+        """Prevent instantiation of this class."""
+        raise TypeError("Constants class cannot be instantiated")

--- a/src/deadline/vred_submitter/vred_submitter.py
+++ b/src/deadline/vred_submitter/vred_submitter.py
@@ -1,0 +1,276 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Hosts the lower-level Deadline Cloud UI. Pipes the relevant render job parameters that the Deadline Cloud UI
+requires to populate its UI elements. Processes VRED render job submission requests via Deadline Cloud API.
+Generates job bundles for render job submission/export purposes.
+"""
+
+import os
+
+from copy import deepcopy
+from dataclasses import fields
+from pathlib import Path
+from typing import Any, Optional
+
+from .assets import AssetIntrospector
+from .constants import Constants
+from .data_classes import RenderSubmitterUISettings
+from .qt_utils import get_qt_yes_no_dialog_prompt_result
+from .scene import Animation, Scene
+from .ui.components.scene_settings_widget import SceneSettingsWidget
+from .utils import get_yaml_contents
+from .vred_logger import get_logger
+from .vred_utils import is_scene_file_modified, get_major_version, save_scene_file
+from ._version import version
+
+from deadline.client.api import (
+    get_deadline_cloud_library_telemetry_client,
+)
+from deadline.client.exceptions import DeadlineOperationError
+from deadline.client.job_bundle._yaml import deadline_yaml_dump
+from deadline.client.job_bundle.submission import AssetReferences
+from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (
+    SubmitJobToDeadlineDialog,
+    JobBundlePurpose,
+)
+
+from PySide6.QtCore import Qt
+
+# Note: this logger can be repurposed/used later
+#
+_global_logger = get_logger(__name__)
+
+
+class VREDSubmitter:
+
+    def __init__(self, parent_window: Any, window_flags: Qt.WindowFlags = Qt.WindowFlags()):
+        """
+        Track parent window, flags, and default job template contents.
+        param: parent_window: the parent Qt window instance that will contain the submitter.
+        param: window_flags: Qt window flags to control window behavior and appearance.
+        """
+        self.parent_window = parent_window
+        self.window_flags = window_flags
+        self.default_job_template = get_yaml_contents(
+            str(Path(__file__).parent / Constants.DEFAULT_JOB_TEMPLATE_FILENAME)
+        )
+
+    def _get_job_template(
+        self,
+        default_job_template: dict[str, Any],
+        settings: RenderSubmitterUISettings,
+    ) -> dict[str, Any]:
+        """
+        Generate a job template based on default template and current settings.
+        param: default_job_template: base template dictionary containing default render job configuration.
+        param settings: Current render submitter UI settings to incorporate into template.
+        raise: KeyError: if required template keys are missing.
+        raise: ValueError: if template values are invalid.
+        return: modified job template with current settings applied.
+        """
+        job_template = deepcopy(default_job_template)
+        job_template[Constants.NAME_FIELD] = settings.name
+        if settings.description:
+            job_template[Constants.DESCRIPTION_FIELD] = settings.description
+        return job_template
+
+    def _get_parameter_values(
+        self,
+        settings: RenderSubmitterUISettings,
+        queue_parameters: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """
+        Produce a list of parameter values for the job template.
+        param: settings: render settings for the submitter UI
+        param: queue_parameters: parameters from the queue tab of the submitter UI
+        return: list of parameter value dictionaries
+        """
+        parameter_values = [
+            {Constants.NAME_FIELD: field.name, Constants.VALUE_FIELD: getattr(settings, field.name)}
+            for field in fields(type(settings))
+        ]
+        # Check for any overlap between the job parameters we've defined and the queue parameters. This is an error,
+        # as we weren't synchronizing the values between the two different tabs where they came from.
+        #
+        parameter_names = {param[Constants.NAME_FIELD] for param in parameter_values}
+        queue_parameter_names = {param[Constants.NAME_FIELD] for param in queue_parameters}
+        parameter_overlap = parameter_names.intersection(queue_parameter_names)
+        if parameter_overlap:
+            raise DeadlineOperationError(
+                f"{Constants.ERROR_QUEUE_PARAM_CONFLICT}{', '.join(parameter_overlap)}"
+            )
+        parameter_values.extend(
+            {
+                Constants.NAME_FIELD: param[Constants.NAME_FIELD],
+                Constants.VALUE_FIELD: param[Constants.VALUE_FIELD],
+            }
+            for param in queue_parameters
+        )
+        return parameter_values
+
+    def show_submitter(self) -> Optional[SubmitJobToDeadlineDialog]:
+        """
+        Populates the necessary settings for showing the VRED render submitter dialog, then displays it.
+        return: SubmitJobToDeadlineDialog instance if successful, None otherwise.
+        """
+        render_settings = self._initialize_render_settings()
+        attachments = self._setup_attachments(render_settings)
+        # Initialize the telemetry client, opt-out is respected
+        get_deadline_cloud_library_telemetry_client().update_common_details(
+            {
+                Constants.DEADLINE_CLOUD_FOR_VRED_SUBMITTER_VERSION_FIELD: version,
+                Constants.VRED_VERSION_FIELD: get_major_version(),
+            }
+        )
+        submitter_dialog = self._create_submitter_dialog(render_settings, attachments)
+        submitter_dialog.setMinimumSize(
+            Constants.MINIMUM_WINDOW_SIZE[0], Constants.MINIMUM_WINDOW_SIZE[1]
+        )
+        submitter_dialog.show()
+        return submitter_dialog
+
+    def _initialize_render_settings(self) -> RenderSubmitterUISettings:
+        """
+        Initialize render UI settings using scene defaults.
+        return: configured settings
+        """
+        render_settings = RenderSubmitterUISettings()
+        # Note: further render settings will be populated through the SceneSettingsWidget's
+        # update_settings()/update_settings_callback() mechanism.
+        render_settings.name = Path(Scene.name()).name
+        render_settings.frame_list = str(Animation.frame_list())
+        render_settings.project_path = Scene.project_path()
+        render_settings.output_path = Scene.output_path()
+        return render_settings
+
+    def _setup_attachments(
+        self, render_settings: RenderSubmitterUISettings
+    ) -> tuple[AssetReferences, AssetReferences]:
+        """
+        Set up auto-detected and user-defined attachments for the render job.
+        param: render_settings: render settings for the submitter UI
+        return: auto-detected and user-defined attachments
+        """
+        auto_detected_attachments = AssetReferences()
+        introspector = AssetIntrospector()
+        auto_detected_attachments.input_filenames = {
+            os.path.normpath(path) for path in introspector.parse_scene_assets()
+        }
+        # Note: additional logic can be added here for auto_detected_attachments.output_directories
+        user_defined_attachments = AssetReferences(
+            input_filenames=set(render_settings.input_filenames),
+            input_directories=set(render_settings.input_directories),
+            output_directories=set(render_settings.output_directories),
+        )
+        return auto_detected_attachments, user_defined_attachments
+
+    def _create_submitter_dialog(
+        self,
+        render_settings: RenderSubmitterUISettings,
+        attachments: tuple[AssetReferences, AssetReferences],
+    ) -> SubmitJobToDeadlineDialog:
+        """
+        Configures and creates a job submission dialog for Deadline Cloud.
+        param: render_settings: render settings for the submitter UI
+        param: attachments auto-detected asset references and user-defined asset references
+        return: configured dialog instance
+        """
+        auto_detected_attachments, user_attachments = attachments
+        conda_packages = f"{Constants.VRED_PRODUCT_NAME.lower()}={get_major_version()}*"
+        return SubmitJobToDeadlineDialog(
+            job_setup_widget_type=SceneSettingsWidget,
+            initial_job_settings=render_settings,
+            initial_shared_parameter_values={
+                Constants.CONDA_PACKAGES_FIELD: conda_packages,
+            },
+            auto_detected_attachments=auto_detected_attachments,
+            attachments=user_attachments,
+            on_create_job_bundle_callback=self._create_job_bundle_callback,
+            parent=self.parent_window,
+            f=self.window_flags,
+            show_host_requirements_tab=True,
+        )
+
+    def _create_job_bundle_callback(
+        self,
+        widget: SubmitJobToDeadlineDialog,
+        job_bundle_dir: str,
+        settings: RenderSubmitterUISettings,
+        queue_parameters: list[dict[str, Any]],
+        asset_references: AssetReferences,
+        host_requirements: Optional[dict[str, Any]] = None,
+        purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
+    ) -> None:
+        """
+        Triggered (via on_create_job_bundle_callback) when there is a dialog-based request to create a job bundle
+        param: widget: reference to the widget hosting the dialog, which triggered this callback
+        param: job_bundle_dir: directory path where bundle files will be written
+        param: settings: render settings for the submitter UI
+        param: queue_parameters: parameters from the queue tab of the submitter UI
+        param: asset_references: collection of asset paths/references
+        param: host_requirements: constraints on host requirements
+        param: purpose: catalyst for creating the job bundle
+        """
+        if is_scene_file_modified() and purpose == JobBundlePurpose.SUBMISSION:
+            dialog_result = get_qt_yes_no_dialog_prompt_result(
+                title=Constants.SCENE_FILE_NOT_SAVED_TITLE,
+                message=Constants.SCENE_FILE_NOT_SAVED_BODY,
+                default_to_yes=False,
+            )
+            if dialog_result:
+                save_scene_file(Scene.name)
+        self._create_job_bundle(
+            job_bundle_dir, settings, queue_parameters, asset_references, host_requirements
+        )
+        attachments: AssetReferences = widget.job_attachments.attachments
+        settings.input_filenames = sorted(attachments.input_filenames)
+        settings.input_directories = sorted(attachments.input_directories)
+
+    def _create_job_bundle(
+        self,
+        job_bundle_dir: str,
+        settings: RenderSubmitterUISettings,
+        queue_parameters: list[dict[str, Any]],
+        asset_references: AssetReferences,
+        host_requirements: Optional[dict[str, Any]],
+    ) -> None:
+        """
+        Create job bundle files (template, parameter values, asset references)
+        param: job_bundle_dir: directory path where bundle files will be written
+        param: settings: render settings for the submitter UI
+        param: queue_parameters: parameters from the queue tab of the submitter UI
+        param: asset_references: collection of asset paths/references
+        param: host_requirements: constraints on host requirements
+        raise: IOError: If unable to write any of the bundle files
+        raise: OSError: If the bundle directory is not accessible
+        """
+        job_bundle_path = Path(job_bundle_dir)
+        job_template = self._get_job_template(
+            default_job_template=self.default_job_template, settings=settings
+        )
+        if host_requirements:
+            for step in job_template[Constants.STEPS_FIELD]:
+                step[Constants.HOST_REQUIREMENTS_FIELD] = host_requirements
+        parameter_values = self._get_parameter_values(
+            queue_parameters=queue_parameters, settings=settings
+        )
+        with open(
+            job_bundle_path / Constants.TEMPLATE_FILENAME,
+            Constants.WRITE_FLAG,
+            encoding=Constants.UTF8_FLAG,
+        ) as file_handle:
+            deadline_yaml_dump(job_template, file_handle, indent=1)
+        with open(
+            job_bundle_path / Constants.PARAMETER_VALUES_FILENAME,
+            Constants.WRITE_FLAG,
+            encoding=Constants.UTF8_FLAG,
+        ) as file_handle:
+            deadline_yaml_dump(
+                {Constants.PARAMETER_VALUES_FIELD: parameter_values}, file_handle, indent=1
+            )
+        with open(
+            job_bundle_path / Constants.ASSET_REFERENCES_FILENAME,
+            Constants.WRITE_FLAG,
+            encoding=Constants.UTF8_FLAG,
+        ) as file_handle:
+            deadline_yaml_dump(asset_references.to_dict(), file_handle, indent=1)

--- a/src/deadline/vred_submitter/vred_submitter_wrapper.py
+++ b/src/deadline/vred_submitter/vred_submitter_wrapper.py
@@ -1,0 +1,73 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Provides a high-level interface to the DeadlineCloudForVRED bootstrapper to create a persistent
+VRED menu for Deadline Cloud. This menu effectively triggers the Deadline Cloud UI via VREDSubmitter.
+"""
+
+from typing import Any, Optional
+
+from .constants import Constants
+from .vred_submitter import VREDSubmitter
+from .vred_utils import assign_scene_transition_event, get_main_window
+
+from PySide6.QtGui import QAction
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QMenu, QWidget
+
+# Track deadline Deadline Cloud dialog instance
+#
+_global_submitter_dialog: Optional[QWidget] = None
+
+
+def scene_file_changed_callback(*dummy_args: Any) -> None:
+    """
+    Callback to close and reset the existing Deadline Cloud dialog.
+    param: dummy_args: conventional variable arguments passed by signal connections (unused)
+    """
+    global _global_submitter_dialog
+    if _global_submitter_dialog is not None:
+        _global_submitter_dialog.close()
+        _global_submitter_dialog = None
+
+
+def add_deadline_cloud_menu() -> None:
+    """
+    Add the Deadline Cloud menu to VRED's main menu bar. Includes:
+    - "Submit to Deadline Cloud" menu item action that triggers the submission dialog
+    - Initialization of necessary callbacks for dialog management between scene file sessions
+    - Note: this should only be invoked once per entire VRED session.
+    """
+    # Initialize callbacks to manage Deadline Cloud dialog state. Connects scene transition events (new scene and
+    # project load) to ensure that the Deadline Cloud dialog is properly closed and reset, preventing a stale state.
+    assign_scene_transition_event(scene_file_changed_callback)
+    vred_menu_bar = get_main_window().menuBar()
+    deadline_cloud_menu = None
+    for child in vred_menu_bar.findChildren(QMenu):
+        if child.title() == Constants.DEADLINE_CLOUD_MENU_NAME:
+            deadline_cloud_menu = child
+            break
+    if deadline_cloud_menu is None:
+        deadline_cloud_menu = QMenu(Constants.DEADLINE_CLOUD_MENU_NAME, vred_menu_bar)
+        deadline_cloud_menu.setObjectName(Constants.DEADLINE_CLOUD_MENU_NAME)
+        vred_menu_bar.addMenu(deadline_cloud_menu)
+    submit_action_exists = any(
+        action.text() == Constants.SUBMIT_TO_DEADLINE_CLOUD_ACTION_NAME
+        for action in deadline_cloud_menu.actions()
+    )
+    if not submit_action_exists:
+        deadline_action = QAction(
+            Constants.SUBMIT_TO_DEADLINE_CLOUD_ACTION_NAME, deadline_cloud_menu
+        )
+        deadline_action.triggered.connect(submit_to_deadline_cloud)
+        deadline_cloud_menu.addAction(deadline_action)
+
+
+def submit_to_deadline_cloud() -> None:
+    """Show the Deadline Cloud submission dialog, while preventing  duplicate dialogs from appearing."""
+    global _global_submitter_dialog
+    if _global_submitter_dialog is not None and _global_submitter_dialog.isVisible():
+        _global_submitter_dialog.raise_()
+        _global_submitter_dialog.activateWindow()
+        return
+    submitter = VREDSubmitter(get_main_window(), Qt.Tool)
+    _global_submitter_dialog = submitter.show_submitter()


### PR DESCRIPTION
Provides an interface to create the VRED menu for Deadline Cloud, which triggers the Deadline Cloud UI (API). Pipes the relevant render job parameters that the Deadline Cloud UI requires to populate its UI. Processes VRED render job submission requests via Deadline Cloud API. Packages job bundle for submission/export purposes.

Note: WIP UI - still making fixes including resolution adjustments to scaling of UI elements.

![image](https://github.com/user-attachments/assets/c652d98d-8a98-4ee2-a910-f26dad76156e)


### What was the problem/requirement? (What/Why)

Need a VRED submitter (backend-logic to interface with Deadline Cloud API)

### What was the solution? (How)

The current implementation that references the Deadline Cloud API and relays render parameters to it.

### What is the impact of this change?

No negative impact.

### How was this change tested?

Checking for the Deadline Cloud UI, checking the generated job bundles.

### Was this change documented?

Will be adding README documentation later.

### Is this a breaking change?

No.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
