### PR TITLE
feat(ci): add additional GitHub workflows/scripts for Python build.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    commit-message: 
+      prefix: "chore(deps):"
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/scripts/get_latest_changelog.py
+++ b/.github/scripts/get_latest_changelog.py
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+This script gets the changelog notes for the latest version of this package. It makes the following assumptions
+1. A file called CHANGELOG.md is in the current directory that has the changelog
+2. The changelog file is formatted in a way such that level 2 headers are:
+    a. The only indication of the beginning of a version's changelog notes.
+    b. Always begin with `## `
+3. The changelog file contains the newest version's changelog notes at the top of the file.
+
+Example CHANGELOG.md:
+```
+## 1.0.0 (2024-02-06)
+
+### BREAKING CHANGES
+* **api**: rename all APIs
+
+## 0.1.0 (2024-02-06)
+
+### Features
+* **api**: add new api
+```
+
+Running this script on the above CHANGELOG.md should return the following contents:
+```
+## 1.0.0 (2024-02-06)
+
+### BREAKING CHANGES
+* **api**: rename all APIs
+
+```
+"""
+import re
+
+h2 = r"^##\s.*$"
+with open("CHANGELOG.md") as f:
+    contents = f.read()
+matches = re.findall(h2, contents, re.MULTILINE)
+changelog = contents[: contents.find(matches[1]) - 1] if len(matches) > 1 else contents
+print(changelog)

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-approve
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -1,0 +1,42 @@
+name: "Build Installers"
+
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        required: true
+        default: Linux
+        type: choice
+        options:
+        - Linux
+        - Windows
+        - MacOS
+      ref_type:
+        required: true
+        default: heads
+        type: choice
+        options:
+        - tags
+        - heads
+      ref:
+        required: true
+        type: string
+        default: mainline
+      environment:
+        required: true
+        type: choice
+        options:
+        - mainline
+
+jobs:
+  BuildInstaller:
+    if: (github.repository == 'aws-deadline/deadline-cloud-for-vred')
+    name: Build Installer
+    uses: aws-deadline/.github/.github/workflows/reusable_build_installers.yml@mainline
+    secrets: inherit
+    with:
+      environment: ${{inputs.environment}}
+      ref_type: ${{inputs.ref_type}}
+      ref: ${{inputs.ref}}
+      oses: "['${{inputs.os}}']"
+      project_name: "deadline-cloud-for-vred"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,14 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "mainline" ]
+  pull_request:
+    branches: [ "mainline" ]
+  schedule:
+    - cron: '0 8 * * MON'
+
+jobs:
+  Analysis:
+    name: Analysis
+    uses: aws-deadline/.github/.github/workflows/reusable_codeql.yml@mainline

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -1,0 +1,32 @@
+name: "Release: Bump"
+
+on:
+  workflow_dispatch:
+    inputs:
+      force_version_bump:
+        required: false
+        default: ""
+        type: choice
+        options:
+        - ""
+        - patch
+        - minor
+        - major
+
+concurrency:
+  group: release
+
+jobs:
+  UnitTests:
+    name: Unit Tests
+    uses: ./.github/workflows/code_quality.yml
+    with:
+      branch: mainline
+
+  Bump:
+    name: Version Bump
+    needs: UnitTests
+    uses: aws-deadline/.github/.github/workflows/reusable_bump.yml@mainline
+    secrets: inherit
+    with:
+      force_version_bump: ${{ inputs.force_version_bump }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -1,0 +1,49 @@
+name: "Release: Publish"
+run-name: "Release: ${{ github.event.head_commit.message }}"
+
+on:
+  push:
+    branches:
+      - mainline
+    paths:
+      - CHANGELOG.md
+
+concurrency:
+  group: release
+
+jobs:
+  Publish:
+    name: Publish Release
+    permissions:
+      id-token: write
+      contents: write
+    uses: aws-deadline/.github/.github/workflows/reusable_publish_v2.yml@mainline
+    with:
+      installer_oses: "['Linux', 'Windows', 'MacOS']"
+    secrets: inherit
+  # PyPI does not support reusable workflows yet
+  # # See https://github.com/pypi/warehouse/issues/11096
+  PublishToPyPI:
+    needs: Publish
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Publish.outputs.tag }}
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          pip install --upgrade hatch
+      - name: Build
+        run: hatch -v build
+      # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Includes the workflows: dependabot, auto_approve, build_installers, codeql, release_bump, release_publish. Some of these (dependabot, codeql) are needed to meet security requirements. Includes a convenience script: get_latest_changelog.py.

### What was the problem/requirement? (What/Why)

Security requirements need code analysis/dependency verification tools.

### What was the solution? (How)

Include the requested GitHub workflows.

### What is the impact of this change?

None

### How was this change tested?

They have been used in other branches as is and work.

### Was this change documented?

In security review docs.

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
