### PR TITLE
fix: introduces a bootstrapper component - figures out DC paths, requests menu to launch submitter 

### DIFF
--- a/vred_submitter_plugin/plug-ins/DeadlineCloudForVRED.py
+++ b/vred_submitter_plugin/plug-ins/DeadlineCloudForVRED.py
@@ -158,6 +158,7 @@ class DeadlineCloudForVRED:
         """
         try:
             from deadline.vred_submitter import vred_submitter_wrapper  # type: ignore
+
             vred_submitter_wrapper.add_deadline_cloud_menu()
             return True
         except Exception as e:


### PR DESCRIPTION
Bootstrapper component exclusively lives in the site-packages area of VRED's own Python installation. The logic contained here determines the state of the Deadline Cloud Client area and the state of its Deadline Cloud for VRED component. Based on those components' states, the Python system path is updated, allowing the VRED submitter and Deadline Cloud Client to launch. The VRED submitter has a menu added (via the Deadline Cloud Client VRED component) - see vred_submitter_wrapper.add_deadline_cloud_menu() in PR #7.

### What was the problem/requirement? (What/Why)

Find the Deadline Cloud Client area, add a menu for the Submitter

### What was the solution? (How)

PATH searching, calling the Submitter code found in PATH

### What is the impact of this change?

None

### How was this change tested?

Tested each exception code path (hiding Deadline Cloud Client area, its VRED component, and generating exceptions in its code)

### Was this change documented?

Partly in the file itself - this documentation could be moved out. It's just that this is one self-contained file on its own in the site-packages area.

### Is this a breaking change?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
