### PR TITLE
feat: add Qt-based Widget UI design definition of render settings for "Job-specific settings" dialog

### DIFF
--- a/src/deadline/vred_submitter/ui/__init__.py
+++ b/src/deadline/vred_submitter/ui/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/src/deadline/vred_submitter/ui/components/__init__.py
+++ b/src/deadline/vred_submitter/ui/components/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/src/deadline/vred_submitter/ui/components/constants.py
+++ b/src/deadline/vred_submitter/ui/components/constants.py
@@ -1,0 +1,231 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Provides a Constants class that focuses on UI design, values to populate"""
+
+from types import MappingProxyType
+from typing import List, Final
+
+
+class ConstantsMeta(type):
+    """Metaclass to prevent modification of class attributes."""
+
+    def __setattr__(cls, name, value):
+        """Prevent modification of class attributes."""
+        raise AttributeError(f"Cannot modify constant '{name}'")
+
+    def __delattr__(cls, name):
+        """Prevent deletion of class attributes."""
+        raise AttributeError(f"Cannot delete constant '{name}'")
+
+
+class Constants(metaclass=ConstantsMeta):
+    """Constants class for UI settings."""
+
+    ABORT_ON_MISSING_TILES_LABEL: Final[str] = "Abort on Missing Tiles"
+    ABORT_ON_MISSING_TILES_LABEL_DESCRIPTION: Final[str] = (
+        "If enabled, the assembly job will fail if it cannot find any of the tiles."
+    )
+    ABORT_ON_MISSING_BACKGROUND_LABEL: Final[str] = "Abort on Missing Background"
+    ABORT_ON_MISSING_BACKGROUND_LABEL_DESCRIPTION: Final[str] = (
+        "If enabled, the render will fail if the background image specified does not exist."
+    )
+    ANIMATION_SETTINGS_DIALOG_NAME: Final[str] = "Animation Settings"
+    ANIMATION_CLIP_LABEL: Final[str] = "Animation Clip"
+    ANIMATION_CLIP_LABEL_DESCRIPTION: Final[str] = "The specific animation clip to render."
+    ANIMATION_TYPE_LABEL: Final[str] = "Animation Type"
+    ANIMATION_TYPE_LABEL_DESCRIPTION: Final[str] = "The type of animation."
+    ANIMATION_TYPE_OPTIONS: Final[List[str]] = ["Clip", "Timeline"]
+    ASSEMBLE_OVER_LABEL: Final[str] = "Assemble Over"
+    ASSEMBLE_OVER_LABEL_DESCRIPTION: Final[str] = "The initial image to assemble over."
+    BACKGROUND_IMAGE_LABEL: Final[str] = "Background Image"
+    BACKGROUND_IMAGE_LABEL_DESCRIPTION: Final[str] = (
+        "The background image file to be used for the assemble over option."
+    )
+    BACKGROUND_IMAGE_OPTIONS: Final[List[str]] = [
+        "Blank Image",
+        "Previous Output",
+        "Selected Image",
+    ]
+    CLEAN_UP_TILES_AFTER_ASSEMBLY_LABEL: Final[str] = "Cleanup Tiles After Assembly"
+    CLEAN_UP_TILES_AFTER_ASSEMBLY_LABEL_DESCRIPTION: Final[str] = (
+        "If enabled, tiles will be deleted after the assembly job is completed."
+    )
+    CLIP_LABEL: Final[str] = "Clip"
+    CUSTOM_SPEED_FIELD_NAME: Final[str] = "_customSpeed"
+    DEFAULT_IMAGE_SIZE_PRESET: Final[str] = "SVGA (800 x 600)"
+    DEFAULT_SCENE_FILE_FPS_COUNT: Final[float] = 24.0
+    DEFAULT_DPI_RESOLUTION: Final[int] = 72
+    DLSS_QUALITY_LABEL: Final[str] = "DLSS Quality"
+    DLSS_QUALITY_LABEL_DESCRIPTION: Final[str] = (
+        "Sets the deep learning supersampling (DLSS) quality."
+    )
+    DLSS_QUALITY_OPTIONS: Final[List[str]] = [
+        "Off",
+        "Performance",
+        "Balance",
+        "Quality",
+        "Ultra Performance",
+    ]
+    ELLIPSIS_LABEL: Final[str] = "..."
+    EMPTY_FRAME_RANGE: Final[str] = "0-0"
+    ENABLE_REGION_RENDERING_LABEL: Final[str] = "Enable Region Rendering"
+    ENABLE_REGION_RENDERING_LABEL_DESCRIPTION: Final[str] = (
+        "If this option is enabled, then the image will be divided into multiple tasks and assembled afterwards."
+    )
+    FRAME_RANGE_BASIC_FORMAT: Final[str] = "%d-%d"
+    FRAME_RANGE_LABEL: Final[str] = "Frame Range"
+    FRAME_RANGE_LABEL_DESCRIPTION: Final[str] = "The list of frames to render."
+    FRAMES_PER_TASK_LABEL: Final[str] = "Frames Per Task"
+    FRAMES_PER_TASK_LABEL_DESCRIPTION: Final[str] = (
+        "The number of frames that will be rendered at a time for each job's task."
+    )
+    IMAGE_SIZE_LABEL: Final[str] = "Image Size (px w,h)"
+    IMAGE_SIZE_LABEL_DESCRIPTION: Final[str] = "The image size in pixels (width and height)"
+    IMAGE_SIZE_PRESET_CUSTOM: Final[str] = "Custom"
+    IMAGE_SIZE_PRESET_FROM_RENDER_WINDOW: Final[str] = "From Render Window"
+    IMAGE_SIZE_PRESETS_LABEL: Final[str] = "Image Size Presets"
+    IMAGE_SIZE_PRESETS_LABEL_DESCRIPTION: Final[str] = (
+        "The available presets for image size and resolution"
+    )
+    IMAGE_SIZE_PRESETS_MAP: MappingProxyType[str, list[int]] = MappingProxyType(
+        {
+            "Custom": [-2, -2, -2],
+            "From Render Window": [-1, -1, -1],
+            "A0 portrait": [9933, 14043, 300],
+            "A0 landscape": [14043, 9933, 300],
+            "A1 portrait": [7016, 9933, 300],
+            "A1 landscape": [9933, 7016, 300],
+            "A2 portrait": [4961, 7016, 300],
+            "A2 landscape": [7016, 4961, 300],
+            "A3 portrait": [3508, 4961, 300],
+            "A3 landscape": [4961, 3508, 300],
+            "A4 portrait": [2480, 3508, 300],
+            "A4 landscape": [3508, 2480, 300],
+            "A5 portrait": [1748, 2480, 300],
+            "A5 landscape": [2480, 1748, 300],
+            "A6 portrait": [1240, 1748, 300],
+            "A6 landscape": [1748, 1240, 300],
+            "UHDV (7680 x 4320)": [7680, 4320, 72],
+            "DCI 4K (4096 x 3112)": [4096, 3112, 72],
+            "4K (4096 x 2160)": [4096, 2160, 72],
+            "QSXGA (2560 x 2048)": [2560, 2048, 72],
+            "WQXGA (2560 x 1600)": [2560, 1600, 72],
+            "DCI 2K (2048 x 1556)": [2048, 1556, 72],
+            "QXGA (2048 x 1536)": [2048, 1536, 72],
+            "WUXGA (1920 x 1200)": [1920, 1200, 72],
+            "HD 1080 (1920 x 1080)": [1920, 1080, 72],
+            "WSXGA+ (1680 x 1050)": [1680, 1050, 72],
+            "UXGA (1600 x 1200)": [1600, 1200, 72],
+            "SXGA+ (1400 x 1050)": [1400, 1050, 72],
+            "SXGA (1280 x 1024)": [1280, 1024, 72],
+            "HD 720 (1280 x 720)": [1280, 720, 72],
+            "XGA (1024 x 768)": [1024, 768, 72],
+            "PAL WIDE (1024 x 576)": [1024, 576, 72],
+            "SVGA (800 x 600)": [800, 600, 72],
+            "WVGA (854 x 480)": [853, 480, 72],
+            "PAL (768 x 576)": [768, 576, 72],
+            "NTSC (720 x 480)": [720, 480, 72],
+            "VGA (640 x 480)": [640, 480, 72],
+            "QVGA (320 x 240)": [320, 240, 72],
+            "CGA (320 x 200)": [320, 200, 72],
+        }
+    )
+    INCH_TO_CM_FACTOR: Final[float] = 2.54
+    JOB_TYPE_LABEL: Final[str] = "Job Type"
+    JOB_TYPE_LABEL_DESCRIPTION: Final[str] = "The type of job to Render."
+    JOB_TYPE_RENDER: Final[str] = "Render"
+    JOB_TYPE_RENDER_QUEUE: Final[str] = "Render Queue"
+    JOB_TYPE_SEQUENCER: Final[str] = "Sequencer"
+    JOB_TYPE_OPTIONS: Final[List[str]] = [
+        JOB_TYPE_RENDER,
+        JOB_TYPE_RENDER_QUEUE,
+        JOB_TYPE_SEQUENCER,
+    ]
+    LONG_TEXT_ENTRY_WIDTH: Final[int] = 500
+    MIN_FRAMES_PER_TASK: Final[int] = 1
+    MIN_DPI: Final[int] = 1
+    MIN_IMAGE_DIMENSION: Final[int] = 1
+    MIN_TILES_PER_DIMENSION: Final[int] = 1
+    MAX_DPI: Final[int] = 1000
+    MAX_FRAMES_PER_TASK: Final[int] = 10000
+    MAX_IMAGE_DIMENSION: Final[int] = 10000
+    MAX_TILES_PER_DIMENSION: Final[int] = 10000
+    MODERATE_TEXT_ENTRY_WIDTH: Final[int] = 300
+    PRINTING_PRECISION_DIGITS_COUNT: Final[int] = 2
+    PRINTING_SIZE_LABEL: Final[str] = "Printing Size (cm w,h)"
+    PRINTING_SIZE_LABEL_DESCRIPTION: Final[str] = (
+        "The printing size in centimeters (width and height)"
+    )
+    RENDER_ANIMATION_LABEL: Final[str] = "Render Animation"
+    RENDER_ANIMATION_LABEL_DESCRIPTION: Final[str] = (
+        "The animation to use, if left blank it will use all enabled clips."
+    )
+    RENDER_QUALITY_LABEL: Final[str] = "Render Quality"
+    RENDER_QUALITY_LABEL_DESCRIPTION: Final[str] = "The Render quality to use."
+    RENDER_QUALITY_OPTIONS: Final[List[str]] = [
+        "Analytic Low",
+        "Analytic High",
+        "Realistic Low",
+        "Realistic High",
+        "Raytracing",
+        "NPR",
+    ]
+    RENDER_QUALITY_DEFAULT: Final[str] = "Realistic High"
+    RENDER_OUTPUT_LABEL: Final[str] = "Render Output"
+    RENDER_OUTPUT_LABEL_DESCRIPTION: Final[str] = "The filename of the image(s) to be rendered."
+    RENDER_VIEW_LABEL: Final[str] = "Render Viewpoint/Camera"
+    RENDER_VIEW_LABEL_DESCRIPTION: Final[str] = "The viewpoint or camera to render"
+    RESOLUTION_LABEL: Final[str] = "Resolution (px/inch)"
+    RESOLUTION_LABEL_DESCRIPTION: Final[str] = "The resolution (pixels per inch)"
+    SECTION_RENDER_OPTIONS: Final[str] = "Render Options"
+    SECTION_SEQUENCER_OPTIONS: Final[str] = "Sequencer Options"
+    SECTION_TILING_SETTINGS: Final[str] = "Tiling Settings"
+    SELECTED_IMAGE_LABEL: Final[str] = "Selected Image"
+    SEQUENCE_NAME_LABEL: Final[str] = "Sequence Name"
+    SEQUENCE_NAME_LABEL_DESCRIPTION: Final[str] = (
+        "The name of the sequence to run, if empty all sequences will be run."
+    )
+    SHORT_TEXT_ENTRY_WIDTH: Final[int] = 200
+    SS_QUALITY_LABEL: Final[str] = "SS Quality"
+    SS_QUALITY_LABEL_DESCRIPTION: Final[str] = (
+        "Sets the regular (non-DLSS) supersampling quality. DLSS quality takes precedence."
+    )
+    SS_QUALITY_OPTIONS: Final[List[str]] = ["Off", "Low", "Medium", "High", "Ultra High"]
+    SUBMIT_DEPENDENT_ASSEMBLY_JOB_LABEL: Final[str] = "Submit Dependent Assembly Job"
+    SUBMIT_DEPENDENT_ASSEMBLY_JOB_LABEL_DESCRIPTION: Final[str] = (
+        "If this option is enabled then an assembly job will be submitted."
+    )
+    TILES_IN_X_LABEL: Final[str] = "Tiles In X"
+    TILES_IN_X_LABEL_DESCRIPTION: Final[str] = (
+        "The number of tiles to horizontally divide the region into."
+    )
+    TILES_IN_Y_LABEL: Final[str] = "Tiles In Y"
+    TILES_IN_Y_LABEL_DESCRIPTION: Final[str] = (
+        "The number of tiles to vertically divide the region into."
+    )
+    TIMELINE_ACTION_NAME: Final[str] = "Timeline"
+    TIMELINE_ANIMATION_PREFS_BUTTON_NAME: Final[str] = "_prefs"
+    TIMELINE_TOOLBAR_NAME: Final[str] = "Timeline_Toolbar"
+    USE_CLIP_RANGE_LABEL: Final[str] = "Use Clip Range"
+    USE_CLIP_RANGE_LABEL_DESCRIPTION: Final[str] = (
+        "When enabled, the frame range will be fixed to the range defined by the "
+        "selected animation clip."
+    )
+    USE_GPU_RAY_TRACING_LABEL: Final[str] = "Use GPU Ray Tracing"
+    USE_GPU_RAY_TRACING_LABEL_DESCRIPTION: Final[str] = "Use GPU Ray Tracing."
+    UTF8_FLAG = "utf-8"
+    VERY_LONG_TEXT_ENTRY_WIDTH: Final[int] = 700
+    VERY_SHORT_TEXT_ENTRY_WIDTH: Final[int] = 150
+    VRED_ALL_FILES_FILTER: Final[str] = "All Files (*.*)"
+    VRED_IMAGE_EXPORT_FILTER: Final[str] = (
+        "*.png (*.png);;*.bmp (*.bmp);;*.dds (*.dds);;*.dib (*.dib);;"
+        "*.exr (*.exr);;*.hdr (*.hdr);;*.jfif (*.jfif);;*.jpe (*.jpe);;"
+        "*.jpeg (*.jpeg);;*.jpg (*.jpg);;*.nrrd (*.nrrd);;*.pbm (*.pbm);;"
+        "*.pgm (*.pgm);;*.png (*.png);;*.pnm (*.pnm);;*.ppm (*.ppm);;"
+        "*.psb (*.psb);;*.psd (*.psd);;*.rle (*.rle);;*.tif (*.tif);;"
+        "*.tiff (*.tiff);;*.vif (*.vif)"
+    )
+
+    def __new__(cls):
+        """Prevent instantiation of this class."""
+        raise TypeError("Constants class cannot be instantiated")

--- a/src/deadline/vred_submitter/ui/components/scene_settings_callbacks.py
+++ b/src/deadline/vred_submitter/ui/components/scene_settings_callbacks.py
@@ -1,0 +1,566 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Represents backend callbacks and UX interaction logic for UI within ("Job-specific settings")"""
+
+from .constants import Constants
+from ...utils import ceil, clamp, is_all_numbers
+from ...vred_utils import (
+    assign_scene_transition_event,
+    get_frame_range_string,
+    get_populated_animation_clip_ranges,
+    get_render_window_size,
+)
+
+from PySide6.QtWidgets import (
+    QFileDialog,
+    QWidget,
+)
+
+
+class SceneSettingsCallbacks:
+    """Callback handler logic applied to a parent class (SceneSettingsWidget) that contains UI objects"""
+
+    # Restrict one-time events to be per scene file session (not on every submission dialog reopening)
+    #
+    invoked_once = False
+
+    def __init__(self, parent_cls: QWidget) -> None:
+        """
+        Initialize the callback handler
+        param: parent_cls: parent widget containing UI elements
+        """
+        self.parent = parent_cls
+        self._register_all_qt_callbacks()
+        # Support scene transition events (new scene and project load resetting settings persistent state and UI)
+        #
+        if not self.invoked_once:
+            assign_scene_transition_event(self.scene_file_changed_callback)
+            self.enable_region_rendering_changed_callback()
+            self.invoked_once = True
+        self._updating_values = False
+
+    def _register_all_qt_callbacks(self) -> None:
+        """Register all UI element-related callbacks"""
+        self.parent.render_job_type_widget.currentIndexChanged.connect(
+            self.job_type_changed_callback
+        )
+        self.parent.use_clip_range_widget.stateChanged.connect(self.use_clip_range_changed_callback)
+        self.parent.render_output_button.pressed.connect(self.select_render_output_callback)
+        self.parent.image_size_presets_widget.currentIndexChanged.connect(
+            self.image_size_preset_selection_changed_callback
+        )
+        self.parent.image_size_x_widget.textChanged.connect(self.image_size_text_changed_callback)
+        self.parent.image_size_y_widget.textChanged.connect(self.image_size_text_changed_callback)
+        self.parent.printing_size_x_widget.textChanged.connect(
+            self.printing_size_text_changed_callback
+        )
+        self.parent.printing_size_y_widget.textChanged.connect(
+            self.printing_size_text_changed_callback
+        )
+        self.parent.resolution_widget.textChanged.connect(self.resolution_text_changed_callback)
+        self.parent.render_animation_widget.stateChanged.connect(self.job_type_changed_callback)
+        self.parent.gpu_ray_tracing_widget.stateChanged.connect(self.job_type_changed_callback)
+        self.parent.animation_type_widget.currentIndexChanged.connect(
+            self.animation_type_selection_changed_callback
+        )
+        self.parent.animation_clip_widget.currentIndexChanged.connect(
+            self.animation_clip_selection_changed_callback
+        )
+        self.parent.enable_region_rendering_widget.stateChanged.connect(
+            self.enable_region_rendering_changed_callback
+        )
+        self.parent.assemble_over_widget.currentIndexChanged.connect(
+            self.assemble_over_changed_callback
+        )
+        self.parent.background_image_button.pressed.connect(self.select_background_file_callback)
+
+    def deregister_all_callbacks(self) -> None:
+        """Deregister all callbacks to avoid unintentional triggering and prepare for new scene file state reset"""
+        self.parent.render_job_type_widget.currentIndexChanged.disconnect()
+        self.parent.use_clip_range_widget.stateChanged.disconnect()
+        self.parent.render_output_button.pressed.disconnect()
+        self.parent.image_size_presets_widget.currentIndexChanged.disconnect()
+        self.parent.image_size_x_widget.textChanged.disconnect()
+        self.parent.image_size_y_widget.textChanged.disconnect()
+        self.parent.printing_size_x_widget.textChanged.disconnect()
+        self.parent.printing_size_y_widget.textChanged.disconnect()
+        self.parent.resolution_widget.textChanged.disconnect()
+        self.parent.render_animation_widget.stateChanged.disconnect()
+        self.parent.gpu_ray_tracing_widget.stateChanged.disconnect()
+        self.parent.animation_type_widget.currentIndexChanged.disconnect()
+        self.parent.animation_clip_widget.currentIndexChanged.disconnect()
+        self.parent.enable_region_rendering_widget.stateChanged.disconnect()
+        self.parent.assemble_over_widget.currentIndexChanged.disconnect()
+        self.parent.background_image_button.pressed.disconnect()
+        self.invoked_once = False
+
+    def job_type_changed_callback(self) -> None:
+        """
+        Updates UI elements based on the selected job type and animation settings.
+        """
+        render_job_type = self.parent.render_job_type_widget.currentText()
+        is_render_job = render_job_type == Constants.JOB_TYPE_RENDER
+        is_sequencer_job = render_job_type == Constants.JOB_TYPE_SEQUENCER
+        is_render_animation_job = self.parent.render_animation_widget.isChecked()
+        is_animation_enabled = is_render_job and is_render_animation_job
+
+        self.parent.group_box_render_options.setVisible(is_render_job)
+        self.parent.group_box_sequencer_options.setVisible(not is_render_job)
+
+        render_controls = [
+            self.parent.render_output_widget,
+            self.parent.render_view_widget,
+            self.parent.render_animation_widget,
+            self.parent.render_quality_widget,
+        ]
+        for control in render_controls:
+            control.setEnabled(is_render_job)
+
+        animation_controls = [
+            self.parent.animation_type_widget,
+            self.parent.animation_clip_widget,
+            self.parent.use_clip_range_widget,
+            self.parent.frame_range_widget,
+            self.parent.frames_per_task_widget,
+        ]
+        for control in animation_controls:
+            control.setEnabled(is_animation_enabled)
+
+        self.parent.sequence_name_widget.setEnabled(is_sequencer_job)
+
+        # Update persisted settings if initialization is complete
+        if self.parent.init_complete:
+            self.parent.populator.persisted_settings_states.update(
+                {
+                    Constants.JOB_TYPE_LABEL: render_job_type,
+                    Constants.RENDER_ANIMATION_LABEL: is_render_animation_job,
+                    Constants.USE_GPU_RAY_TRACING_LABEL: self.parent.gpu_ray_tracing_widget.isChecked(),
+                }
+            )
+
+    def enable_region_rendering_changed_callback(self) -> None:
+        """
+        Updates UI elements when region rendering is enabled/disabled.
+        """
+        enabled = self.parent.enable_region_rendering_widget.isChecked()
+        # All UI elements that should be enabled/disabled together
+        region_rendering_controls = [
+            self.parent.tiles_in_x_label,
+            self.parent.tiles_in_x_widget,
+            self.parent.tiles_in_y_label,
+            self.parent.tiles_in_y_widget,
+            self.parent.submit_dependent_assembly_widget,
+            self.parent.cleanup_tiles_widget,
+            self.parent.abort_on_missing_tiles_widget,
+            self.parent.abort_on_missing_background_widget,
+            self.parent.assemble_over_label,
+            self.parent.assemble_over_widget,
+        ]
+        for control in region_rendering_controls:
+            control.setEnabled(enabled)
+        # Update dependent UI elements
+        self.assemble_over_changed_callback()
+
+    def image_size_preset_selection_changed_callback(self) -> None:
+        """
+        Updates image dimensions and resolution when an image size preset is selected.
+        Persists the selection if initialization is complete.
+        """
+        preset_name = self.parent.image_size_presets_widget.currentText()
+        if self.parent.init_complete:
+            self.parent.populator.persisted_settings_states[Constants.IMAGE_SIZE_PRESETS_LABEL] = (
+                self.parent.image_size_presets_widget.currentIndex()
+            )
+        if preset_name == Constants.IMAGE_SIZE_PRESET_CUSTOM:
+            return
+        elif preset_name == Constants.IMAGE_SIZE_PRESET_FROM_RENDER_WINDOW:
+            # Consider determining the current render window used and resolution DPI.
+            #
+            width, height = get_render_window_size()
+            self._set_render_pixel_resolution(width, height, Constants.DEFAULT_DPI_RESOLUTION)
+        elif preset_name and preset_name in Constants.IMAGE_SIZE_PRESETS_MAP:
+            [width, height, resolution] = Constants.IMAGE_SIZE_PRESETS_MAP[preset_name]
+            self._set_render_pixel_resolution(width, height, resolution)
+            self._update_image_presets_selection(width, height, resolution)
+
+    def image_size_text_changed_callback(self):
+        """
+        Updates printing size based on image dimensions and resolution.
+        It recalculates the printing dimensions based on the new pixel dimensions.
+        Note: this callback is triggered when the user changes the image width or height.
+        """
+        # Avoid recursive updates and validate inputs
+        if self._updating_values:
+            return
+        if not is_all_numbers(
+            [
+                self.parent.image_size_x_widget.text(),
+                self.parent.image_size_y_widget.text(),
+                self.parent.resolution_widget.text(),
+            ]
+        ):
+            return
+        self._updating_values = True
+        try:
+            # Set to custom preset
+            self.parent.image_size_presets_widget.setCurrentIndex(0)
+            # Apply clamping constraints to dimensions and resolution and only update UI if values match
+            #
+            width = int(
+                clamp(
+                    int(self.parent.image_size_x_widget.text()),
+                    Constants.MIN_IMAGE_DIMENSION,
+                    Constants.MAX_IMAGE_DIMENSION,
+                )
+            )
+            height = int(
+                clamp(
+                    int(self.parent.image_size_y_widget.text()),
+                    Constants.MIN_IMAGE_DIMENSION,
+                    Constants.MAX_IMAGE_DIMENSION,
+                )
+            )
+            resolution = int(
+                clamp(
+                    int(self.parent.resolution_widget.text()), Constants.MIN_DPI, Constants.MAX_DPI
+                )
+            )
+            self._update_dimension_fields_if_changed(width, height, resolution)
+            # Compute and update printing size
+            #
+            printing_width = float(
+                ceil(
+                    width * Constants.INCH_TO_CM_FACTOR / resolution,
+                    Constants.PRINTING_PRECISION_DIGITS_COUNT,
+                )
+            )
+            printing_height = float(
+                ceil(
+                    height * Constants.INCH_TO_CM_FACTOR / resolution,
+                    Constants.PRINTING_PRECISION_DIGITS_COUNT,
+                )
+            )
+            self._update_printing_size_fields(printing_width, printing_height)
+        finally:
+            self._update_image_presets_selection(width, height, resolution)
+            self._updating_values = False
+
+    def _update_dimension_fields_if_changed(self, width: int, height: int, resolution: int) -> None:
+        """
+        Updates dimension fields their values were changed.
+        param: width : Clamped width value
+        param: height: Clamped height value
+        param: resolution: Clamped resolution value
+        """
+        if int(self.parent.image_size_x_widget.text()) != width:
+            self.parent.image_size_x_widget.setText(str(width))
+        if int(self.parent.image_size_y_widget.text()) != height:
+            self.parent.image_size_y_widget.setText(str(height))
+        if int(self.parent.resolution_widget.text()) != resolution:
+            self.parent.resolution_widget.setText(str(resolution))
+
+    def _update_printing_size_fields(self, width: float, height: float) -> None:
+        """
+        Updates printing size fields without triggering callbacks.
+        param: width: printing width in cm
+        param: height: printing height in cm
+        """
+        self.parent.printing_size_x_widget.blockSignals(True)
+        self.parent.printing_size_y_widget.blockSignals(True)
+        self.parent.printing_size_x_widget.setText(str(width))
+        self.parent.printing_size_y_widget.setText(str(height))
+        self.parent.printing_size_x_widget.blockSignals(False)
+        self.parent.printing_size_y_widget.blockSignals(False)
+
+    def _update_image_size_fields(self, width: int, height: int) -> None:
+        """
+        Updates image size fields without triggering callbacks.
+        param: width: printing width in pixels
+        param: height: printing height in pixel
+        """
+        self.parent.image_size_x_widget.blockSignals(True)
+        self.parent.image_size_y_widget.blockSignals(True)
+        self.parent.image_size_x_widget.setText(str(width))
+        self.parent.image_size_y_widget.setText(str(height))
+        self.parent.image_size_x_widget.blockSignals(False)
+        self.parent.image_size_y_widget.blockSignals(False)
+
+    def printing_size_text_changed_callback(self):
+        """
+        Update image dimensions based on printing size and resolution.
+        Note: This callback is triggered when the user changes the printing width or height.
+        """
+        # Avoid recursive updates and validate inputs
+        if self._updating_values:
+            return
+        if not is_all_numbers(
+            [
+                self.parent.printing_size_x_widget.text(),
+                self.parent.printing_size_y_widget.text(),
+                self.parent.resolution_widget.text(),
+            ]
+        ):
+            return
+        self._updating_values = True
+        try:
+            # Set to custom preset
+            self.parent.image_size_presets_widget.setCurrentIndex(0)
+            printing_width = float(self.parent.printing_size_x_widget.text())
+            printing_height = float(self.parent.printing_size_y_widget.text())
+            resolution = int(
+                clamp(
+                    int(self.parent.resolution_widget.text()), Constants.MIN_DPI, Constants.MAX_DPI
+                )
+            )
+            # Update resolution if it was clamped
+            if int(self.parent.resolution_widget.text()) != resolution:
+                self.parent.resolution_widget.setText(str(resolution))
+            resolution = int(self.parent.resolution_widget.text())
+            width = int(
+                self._calculate_clamped_pixel_dimension(
+                    printing_width,
+                    resolution,
+                    Constants.MIN_IMAGE_DIMENSION,
+                    Constants.MAX_IMAGE_DIMENSION,
+                )
+            )
+            height = int(
+                self._calculate_clamped_pixel_dimension(
+                    printing_height,
+                    resolution,
+                    Constants.MIN_IMAGE_DIMENSION,
+                    Constants.MAX_IMAGE_DIMENSION,
+                )
+            )
+            self._update_image_size_fields(width, height)
+            # Recalculate printing dimensions based on clamped values
+            #
+            self._recalculate_and_update_printing_dimensions_if_needed(
+                width, height, printing_width, printing_height, resolution
+            )
+        finally:
+            self._update_image_presets_selection(width, height, resolution)
+            self._updating_values = False
+
+    def _recalculate_and_update_printing_dimensions_if_needed(
+        self,
+        width: int,
+        height: int,
+        printing_width: float,
+        printing_height: float,
+        resolution: int,
+    ) -> None:
+        """
+        Recalculates and updates clamped printing dimensions if pixel dimensions were changed.
+        param: width: current pixel width.
+        param: height: current pixel height.
+        param: printing_width: original printing width.
+        param: printing_height: original printing height.
+        param: resolution: current resolution.
+        """
+        expected_width = int(
+            ceil(
+                float(printing_width * resolution / Constants.INCH_TO_CM_FACTOR),
+                Constants.PRINTING_PRECISION_DIGITS_COUNT,
+            )
+        )
+        expected_height = int(
+            ceil(
+                float(printing_height * resolution / Constants.INCH_TO_CM_FACTOR),
+                Constants.PRINTING_PRECISION_DIGITS_COUNT,
+            )
+        )
+        if width != expected_width or height != expected_height:
+            # Recalculate printing dimensions based on clamped pixel dimensions
+            new_printing_width = ceil(
+                width * Constants.INCH_TO_CM_FACTOR / resolution,
+                Constants.PRINTING_PRECISION_DIGITS_COUNT,
+            )
+            new_printing_height = ceil(
+                height * Constants.INCH_TO_CM_FACTOR / resolution,
+                Constants.PRINTING_PRECISION_DIGITS_COUNT,
+            )
+            self.parent.printing_size_x_widget.setText(str(new_printing_width))
+            self.parent.printing_size_y_widget.setText(str(new_printing_height))
+
+    def _set_render_pixel_resolution(self, width: int, height: int, resolution: int) -> None:
+        """
+        Set the render pixel resolution and update related UI elements.
+        param: width: image width in pixels
+        param: height: image height in pixels
+        param: resolution: resolution in pixels per inch
+        """
+        # Apply constraints to all values
+        self.parent.image_size_x_widget.setText(
+            str(clamp(int(width), Constants.MIN_IMAGE_DIMENSION, Constants.MAX_IMAGE_DIMENSION))
+        )
+        self.parent.image_size_y_widget.setText(
+            str(clamp(int(height), Constants.MIN_IMAGE_DIMENSION, Constants.MAX_IMAGE_DIMENSION))
+        )
+        self.parent.resolution_widget.setText(
+            str(clamp(int(resolution), Constants.MIN_DPI, Constants.MAX_DPI))
+        )
+        printing_width = ceil(
+            float(width / resolution * Constants.INCH_TO_CM_FACTOR),
+            Constants.PRINTING_PRECISION_DIGITS_COUNT,
+        )
+        printing_height = ceil(
+            float(height / resolution * Constants.INCH_TO_CM_FACTOR),
+            Constants.PRINTING_PRECISION_DIGITS_COUNT,
+        )
+        self.parent.printing_size_x_widget.setText(str(printing_width))
+        self.parent.printing_size_y_widget.setText(str(printing_height))
+
+    def _calculate_clamped_pixel_dimension(
+        self, printing_dimension: float, resolution: int, min_dimension: int, max_dimension: int
+    ) -> int:
+        """
+        Calculates and clamps pixel dimension from printing dimension.
+        param: printing_dimension: dimension in cm
+        param: resolution (int): resolution in DPI
+        param: min_dimension: minimum allowed pixel dimension
+        param: max_dimension: maximum allowed pixel dimension
+        return: calculated clamped pixel dimension
+        """
+        pixel_dimension = int(
+            ceil(
+                float(printing_dimension * resolution / Constants.INCH_TO_CM_FACTOR),
+                Constants.PRINTING_PRECISION_DIGITS_COUNT,
+            )
+        )
+        return int(clamp(pixel_dimension, min_dimension, max_dimension))
+
+    def _update_image_presets_selection(self, width: int, height: int, resolution: int) -> None:
+        """
+        Update the image preset selection based on specified image dimensions
+        param: width: image width in pixels
+        param: height: image height in pixels
+        param: resolution: resolution in pixels per inch
+        """
+        # Match to a custom resolution or an existing resolution preset
+        changed_render_dimension = [width, height, resolution]
+        render_dimensions_list = list(Constants.IMAGE_SIZE_PRESETS_MAP.values())
+        # Custom preset index (by convention)
+        preset_index = 0
+        if changed_render_dimension in render_dimensions_list:
+            preset_index = render_dimensions_list.index(changed_render_dimension)
+        self.parent.image_size_presets_widget.setCurrentIndex(preset_index)
+
+    def resolution_text_changed_callback(self) -> None:
+        """Adjusts image resolution based on constant printing size and DPI"""
+        self.printing_size_text_changed_callback()
+
+    def animation_clip_selection_changed_callback(self) -> None:
+        """
+        Adjusts frame range data based on a clip's range when the 'use clip range' option is enabled.
+        """
+        if not self.parent.init_complete:
+            return
+        anim_clip_name = self.parent.animation_clip_widget.currentText()
+        self.parent.populator.persisted_settings_states[Constants.ANIMATION_CLIP_LABEL] = (
+            self.parent.animation_clip_widget.currentIndex()
+        )
+        if not self.parent.use_clip_range_widget.isChecked():
+            return
+        # Set frame range based on selected clip
+        if anim_clip_name and anim_clip_name in self.parent.populator.animation_clip_ranges_map:
+            start_frame, end_frame = self.parent.populator.animation_clip_ranges_map[anim_clip_name]
+            frame_range_text = Constants.FRAME_RANGE_BASIC_FORMAT % (start_frame, end_frame)
+        else:
+            frame_range_text = Constants.EMPTY_FRAME_RANGE
+        self.parent.frame_range_widget.setText(frame_range_text)
+
+    def animation_type_selection_changed_callback(self) -> None:
+        """
+        Adjusts UI options based on the selected animation type (clip or timeline).
+        """
+        if not self.parent.init_complete:
+            return
+        clip_type_enabled = self.parent.animation_type_widget.currentText() == Constants.CLIP_LABEL
+        self.parent.populator.persisted_settings_states[Constants.ANIMATION_TYPE_LABEL] = (
+            self.parent.animation_type_widget.currentIndex()
+        )
+        # Update UI controls based on animation type
+        self.parent.animation_clip_widget.setEnabled(clip_type_enabled)
+        self.parent.use_clip_range_widget.setEnabled(clip_type_enabled)
+        if clip_type_enabled:
+            # For clips: frame range is editable only when not using clip's predefined range
+            self.parent.frame_range_widget.setEnabled(
+                not self.parent.use_clip_range_widget.isChecked()
+            )
+        else:
+            # For timelines: frame range is always editable
+            self.parent.frame_range_widget.setEnabled(True)
+
+    def use_clip_range_changed_callback(self) -> None:
+        """
+        Adjusts frame range data based on the 'use clip range' option being enabled/disabled.
+        """
+        if not self.parent.init_complete:
+            return
+        enabled = self.parent.use_clip_range_widget.isChecked()
+        self.parent.populator.persisted_settings_states[Constants.USE_CLIP_RANGE_LABEL] = enabled
+        self.parent.frame_range_widget.setEnabled(not enabled)
+        if enabled:
+            # Check if there are animation clips available (beyond the empty one)
+            if len(self.parent.populator.animation_clip_ranges_map) > 1:
+                # Get current clip name and refresh clip ranges
+                anim_clip_name = self.parent.animation_clip_widget.currentText()
+                self.parent.populator.animation_clip_ranges_map = (
+                    get_populated_animation_clip_ranges()
+                )
+                # Get range for selected clip and update UI
+                if anim_clip_name in self.parent.populator.animation_clip_ranges_map:
+                    start_frame, end_frame = self.parent.populator.animation_clip_ranges_map[
+                        anim_clip_name
+                    ]
+                    frame_range_text = Constants.FRAME_RANGE_BASIC_FORMAT % (start_frame, end_frame)
+                    self.parent.frame_range_widget.setText(frame_range_text)
+        else:
+            self.parent.frame_range_widget.setText(get_frame_range_string())
+
+    def assemble_over_changed_callback(self) -> None:
+        """Adjusts options based on the active "assemble over" option being enabled"""
+        enabled = self.parent.enable_region_rendering_widget.isChecked() and (
+            self.parent.assemble_over_widget.currentText() == Constants.SELECTED_IMAGE_LABEL
+        )
+        self.parent.backgroundImageLabel.setEnabled(enabled)
+        self.parent.background_image_widget.setEnabled(enabled)
+        self.parent.background_image_button.setEnabled(enabled)
+
+    def select_render_output_callback(self) -> None:
+        """Opens a file dialog to select a background image file."""
+        new_output_file = QFileDialog.getSaveFileName(
+            self.parent,
+            Constants.RENDER_OUTPUT_LABEL,
+            self.parent.render_output_widget.text(),
+            Constants.VRED_IMAGE_EXPORT_FILTER,
+        )
+        if new_output_file:
+            if isinstance(new_output_file, tuple) and len(new_output_file) > 0:
+                new_output_file = new_output_file[0]
+                if not new_output_file:
+                    return
+            self.parent.render_output_widget.setText(new_output_file)
+
+    def select_background_file_callback(self) -> None:
+        """Opens a file dialog to select a background image file."""
+        new_background_file = QFileDialog.getOpenFileName(
+            self.parent,
+            Constants.BACKGROUND_IMAGE_LABEL,
+            self.parent.background_image_widget.text(),
+            Constants.VRED_ALL_FILES_FILTER,
+        )
+        if new_background_file:
+            if isinstance(new_background_file, tuple) and len(new_background_file) > 0:
+                new_background_file = new_background_file[0]
+                if not new_background_file:
+                    return
+            self.parent.background_image_widget.setText(new_background_file)
+
+    def scene_file_changed_callback(self, *dummy_args) -> None:
+        """
+        Removes persisted settings (normally called on scene file reset)
+        param: dummy_args: conventional variable arguments passed by signal connections (unused)
+        """
+        self.parent.populator.persisted_settings_states.clear()

--- a/src/deadline/vred_submitter/ui/components/scene_settings_populator.py
+++ b/src/deadline/vred_submitter/ui/components/scene_settings_populator.py
@@ -1,0 +1,298 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Provides backend UI value population and interpretation in ("Job-specific settings")"""
+
+import os
+
+from typing import Any, Dict
+
+from .constants import Constants
+from ...data_classes import RenderSubmitterUISettings
+from ...utils import bool_to_str, DynamicKeyValueObject
+from ...vred_utils import (
+    get_active_camera_name,
+    get_animation_clips_list,
+    get_frame_range_string,
+    get_frame_range_components,
+    get_populated_animation_clip_ranges,
+    get_render_animation,
+    get_render_filename,
+    get_scene_full_path,
+    get_views_list,
+)
+
+from PySide6.QtWidgets import QWidget
+
+
+class SceneSettingsPopulator:
+    """UI value population logic applied to a parent class (SceneSettingsWidget) - defines corresponding UI objects"""
+
+    # Persist setting states between times when the Deadline Cloud submitter dialog is re-opened
+    # (for UX purposes: prevents having to re-choose the same options when re-opening that dialog)
+    #
+    persisted_settings_states: Dict[str, Any] = {}
+
+    def __init__(self, parent_cls: QWidget, initial_settings: RenderSubmitterUISettings) -> None:
+        """
+        Prepares UI elements with populated render settings values from initial_settings and manages persisted settings.
+        param: parent_cls: parent widget containing UI elements.
+        param: initial_settings: maintains values for all render submission parameters.
+        """
+        self.parent = parent_cls
+        # Note: values are updated when the submitter dialog is re-opened!
+        #
+        self.animation_clip_ranges_map = {"": [0.0, 0.0]}
+        self._configure_ui_settings_base_options()
+        self._configure_ui_settings(initial_settings)
+        # Persisted settings will take precedence (in UI elements) over initial settings/defaults
+        self._load_persisted_settings_states()
+
+    def _configure_ui_settings(self, settings: RenderSubmitterUISettings) -> None:
+        """
+        Populates default field values (contained within the settings object) into individual UI widgets
+        param: settings: maintains values for all render submission parameters.
+        Note: excluded unimplemented settings (not traditionally submitter UI exposed):
+           IncludeAlphaChannel, OverrideRenderPass, PremultiplyAlpha, TonemapHDR
+        Note: excluded internal settings (not submitter UI exposed):
+           JobScriptDir OutputFileNamePrefix, OutputFormat, OutputDir, SceneFile
+        Note: excluded (pending implementation changes) - settings exposed as one aggregate field:
+           EndFrame, FrameStep, StartFrame
+        """
+        self.parent.abort_on_missing_background_widget.setChecked(settings.AbortOnMissingBackground)
+        self.parent.abort_on_missing_tiles_widget.setChecked(settings.AbortOnMissingTiles)
+        self.parent.animation_clip_widget.setCurrentText(settings.AnimationClip)
+        self.parent.animation_type_widget.setCurrentText(settings.AnimationType)
+        self.parent.assemble_over_widget.setCurrentText(settings.AssembleOver)
+        self.parent.background_image_widget.setText(settings.BackgroundImage)
+        self.parent.cleanup_tiles_widget.setChecked(settings.CleanupTilesAfterAssembly)
+        self.parent.dlss_quality_widget.setCurrentText(settings.DLSSQuality)
+        self.parent.resolution_widget.setText(str(settings.DPI))
+        self.parent.frames_per_task_widget.setValue(settings.FramesPerTask)
+        self.parent.gpu_ray_tracing_widget.setChecked(settings.GPURaytracing)
+        self.parent.image_size_y_widget.setText(str(settings.ImageHeight))
+        self.parent.image_size_x_widget.setText(str(settings.ImageWidth))
+        self.parent.render_job_type_widget.setCurrentText(settings.JobType)
+        self.parent.enable_region_rendering_widget.setChecked(settings.RegionRendering)
+        self.parent.render_animation_widget.setChecked(settings.RenderAnimation)
+        self.parent.tiles_in_x_widget.setValue(Constants.MIN_TILES_PER_DIMENSION)
+        self.parent.tiles_in_y_widget.setValue(Constants.MIN_TILES_PER_DIMENSION)
+        self.parent.render_quality_widget.setCurrentText(settings.RenderQuality)
+        self.parent.ss_quality_widget.setCurrentText(settings.SSQuality)
+        self.parent.sequence_name_widget.setText(settings.SequenceName)
+        self.parent.submit_dependent_assembly_widget.setChecked(settings.SubmitDependentAssemblyJob)
+        self.parent.render_view_widget.setCurrentText(str(settings.View))
+
+    def _configure_ui_settings_base_options(self) -> None:
+        """
+        Populates runtime-known values and standard option choices into UI elements and resets their state.
+        """
+        # Initialize job type options
+        self.parent.render_job_type_widget.addItems(Constants.JOB_TYPE_OPTIONS)
+
+        # Set output path and frame range
+        self.parent.render_output_widget.setText(get_render_filename())
+        self.parent.frame_range_widget.setText(get_frame_range_string())
+        self.parent.frame_range_widget.setEnabled(False)
+        self.parent.render_animation_widget.setChecked(get_render_animation())
+
+        # Configure camera view settings
+        active_camera_name = get_active_camera_name()
+        views_list = get_views_list()
+        self.parent.render_view_widget.addItems(views_list)
+        self.parent.render_view_widget.setCurrentIndex(views_list.index(active_camera_name))
+
+        # Animation Clips Support - includes 'empty' clip
+        self.parent.animation_clip_widget.setEnabled(False)
+        anim_clips_list = get_animation_clips_list()
+        if len(anim_clips_list) > 1:
+            self.parent.animation_clip_widget.addItems(anim_clips_list)
+            # Should be empty clip name at top of list (for no animation clip)
+            self.parent.animation_clip_widget.setCurrentIndex(0)
+            self.animation_clip_ranges_map = get_populated_animation_clip_ranges()
+
+        # Configure quality settings
+        self.parent.render_quality_widget.addItems(Constants.RENDER_QUALITY_OPTIONS)
+        self.parent.render_quality_widget.setCurrentIndex(
+            self.parent.render_quality_widget.findText(Constants.RENDER_QUALITY_DEFAULT)
+        )
+        self.parent.dlss_quality_widget.addItems(Constants.DLSS_QUALITY_OPTIONS)
+        self.parent.dlss_quality_widget.setCurrentIndex(0)
+        self.parent.ss_quality_widget.addItems(Constants.SS_QUALITY_OPTIONS)
+        self.parent.ss_quality_widget.setCurrentIndex(0)
+
+        # Set the default image size preset (for image size and resolution)
+        image_size_preset_index = 0
+        self.parent.image_size_presets_widget.addItems(Constants.IMAGE_SIZE_PRESETS_MAP.keys())
+        if Constants.DEFAULT_IMAGE_SIZE_PRESET in Constants.IMAGE_SIZE_PRESETS_MAP:
+            image_size_preset_index = list(Constants.IMAGE_SIZE_PRESETS_MAP.keys()).index(
+                Constants.DEFAULT_IMAGE_SIZE_PRESET
+            )
+        self.parent.image_size_presets_widget.setCurrentIndex(image_size_preset_index)
+        self.parent.callbacks.image_size_preset_selection_changed_callback()
+
+        # Configure animation and assembly settings
+        self.parent.animation_type_widget.addItems(Constants.ANIMATION_TYPE_OPTIONS)
+        self.parent.animation_type_widget.setCurrentIndex(0)
+        self.parent.submit_dependent_assembly_widget.setChecked(True)
+        self.parent.assemble_over_widget.addItems(Constants.BACKGROUND_IMAGE_OPTIONS)
+
+    def _load_persisted_settings_states(self) -> None:
+        """
+        Populates persisted settings states into UI elements (if available)
+        """
+        try:
+            if Constants.RENDER_OUTPUT_LABEL in self.persisted_settings_states:
+                self.parent.render_output_widget.setText(
+                    self.persisted_settings_states[Constants.RENDER_OUTPUT_LABEL]
+                )
+            if Constants.IMAGE_SIZE_PRESETS_LABEL in self.persisted_settings_states:
+                self.parent.image_size_presets_widget.setCurrentIndex(
+                    self.persisted_settings_states[Constants.IMAGE_SIZE_PRESETS_LABEL]
+                )
+            if Constants.USE_GPU_RAY_TRACING_LABEL in self.persisted_settings_states:
+                self.parent.gpu_ray_tracing_widget.setChecked(
+                    self.persisted_settings_states[Constants.USE_GPU_RAY_TRACING_LABEL]
+                )
+            if Constants.JOB_TYPE_LABEL in self.persisted_settings_states:
+                self.parent.render_job_type_widget.setCurrentIndex(
+                    self.persisted_settings_states[Constants.JOB_TYPE_LABEL]
+                )
+            if self.parent.render_job_type_widget.currentIndex() == 0:
+                if Constants.RENDER_ANIMATION_LABEL in self.persisted_settings_states:
+                    self.parent.render_animation_widget.setChecked(
+                        self.persisted_settings_states[Constants.RENDER_ANIMATION_LABEL]
+                    )
+                if Constants.ANIMATION_TYPE_LABEL in self.persisted_settings_states:
+                    self.parent.animation_type_widget.setCurrentIndex(
+                        self.persisted_settings_states[Constants.ANIMATION_TYPE_LABEL]
+                    )
+                if Constants.USE_CLIP_RANGE_LABEL in self.persisted_settings_states:
+                    self.parent.use_clip_range_widget.setChecked(
+                        self.persisted_settings_states[Constants.USE_CLIP_RANGE_LABEL]
+                    )
+                if Constants.ANIMATION_CLIP_LABEL in self.persisted_settings_states:
+                    self.parent.animation_clip_widget.setCurrentIndex(
+                        self.persisted_settings_states[Constants.ANIMATION_CLIP_LABEL]
+                    )
+                if Constants.RENDER_QUALITY_LABEL in self.persisted_settings_states:
+                    self.parent.render_quality_widget.setCurrentIndex(
+                        self.persisted_settings_states[Constants.RENDER_QUALITY_LABEL]
+                    )
+                if Constants.SS_QUALITY_LABEL in self.persisted_settings_states:
+                    self.parent.ss_quality_widget.setCurrentIndex(
+                        self.persisted_settings_states[Constants.SS_QUALITY_LABEL]
+                    )
+                if Constants.DLSS_QUALITY_LABEL in self.persisted_settings_states:
+                    self.parent.dlss_quality_widget.setCurrentIndex(
+                        self.persisted_settings_states[Constants.DLSS_QUALITY_LABEL]
+                    )
+        except Exception:
+            pass
+
+    def update_settings_callback(self, settings: RenderSubmitterUISettings) -> None:
+        """
+        Updates a scene settings object - populates it with the latest UI values using the OpenJD typing convention.
+        (This is typically called when Deadline Cloud is exporting or submitting a render job)
+        param: settings: maintains values for all render submission parameters.
+        Note: important to synchronize to the data fields exposed in template.yaml - matching those to Qt controls.
+        Note: if an attribute's value isn't exporting to the parameters YAML, first check that its attribute is
+              included in the RenderSubmitterUISettings (settings) dataclass definition.
+        Note: some values are set to False - they aren't currently implemented or are pending implementation
+        """
+        settings.StartFrame, settings.EndFrame, settings.FrameStep = get_frame_range_components(
+            self.parent.frame_range_widget.text()
+        )
+        attrs = DynamicKeyValueObject(settings.__dict__)
+        settings.__dict__.update(
+            {
+                attrs.AbortOnMissingBackground.__name__: bool_to_str(  # type: ignore[attr-defined]
+                    self.parent.abort_on_missing_background_widget.isChecked()
+                ),
+                attrs.AbortOnMissingTiles.__name__: bool_to_str(  # type: ignore[attr-defined]
+                    self.parent.abort_on_missing_tiles_widget.isChecked()
+                ),
+                attrs.AnimationClip.__name__: str(  # type: ignore[attr-defined]
+                    self.parent.animation_clip_widget.currentText()
+                ),
+                attrs.AnimationType.__name__: str(  # type: ignore[attr-defined]
+                    self.parent.animation_type_widget.currentText()
+                ),
+                attrs.AssembleOver.__name__: str(  # type: ignore[attr-defined]
+                    self.parent.assemble_over_widget.currentText()
+                ),
+                attrs.BackgroundImage.__name__: str(  # type: ignore[attr-defined]
+                    self.parent.background_image_widget.text()
+                ),
+                attrs.CleanupTilesAfterAssembly.__name__: bool_to_str(  # type: ignore[attr-defined]
+                    self.parent.cleanup_tiles_widget.isChecked()
+                ),
+                attrs.DLSSQuality.__name__: str(  # type: ignore[attr-defined]
+                    self.parent.dlss_quality_widget.currentText()
+                ),
+                attrs.DPI.__name__: int(  # type: ignore[attr-defined]
+                    self.parent.resolution_widget.text()
+                ),
+                attrs.FramesPerTask.__name__: int(  # type: ignore[attr-defined]
+                    self.parent.frames_per_task_widget.value()
+                ),
+                attrs.GPURaytracing.__name__: bool_to_str(  # type: ignore[attr-defined]
+                    self.parent.gpu_ray_tracing_widget.isChecked()
+                ),
+                attrs.ImageHeight.__name__: int(  # type: ignore[attr-defined]
+                    self.parent.image_size_y_widget.text()
+                ),
+                attrs.ImageWidth.__name__: int(  # type: ignore[attr-defined]
+                    self.parent.image_size_x_widget.text()
+                ),
+                attrs.IncludeAlphaChannel.__name__: bool_to_str(False),  # type: ignore[attr-defined]
+                attrs.JobType.__name__: str(  # type: ignore[attr-defined]
+                    self.parent.render_job_type_widget.currentText()
+                ),
+                attrs.OutputDir.__name__: str(  # type: ignore[attr-defined]
+                    os.path.normpath(os.path.dirname(self.parent.render_output_widget.text()))
+                ),
+                attrs.OutputFileNamePrefix.__name__: str(  # type: ignore[attr-defined]
+                    os.path.basename(self.parent.render_output_widget.text())
+                ),
+                attrs.OutputFormat.__name__: str(  # type: ignore[attr-defined]
+                    os.path.splitext(self.parent.render_output_widget.text())[1][1:].upper()
+                ),
+                attrs.OverrideRenderPass.__name__: bool_to_str(False),  # type: ignore[attr-defined]
+                attrs.PremultiplyAlpha.__name__: bool_to_str(False),  # type: ignore[attr-defined]
+                attrs.RegionRendering.__name__: bool_to_str(  # type: ignore[attr-defined]
+                    self.parent.enable_region_rendering_widget.isChecked()
+                ),
+                attrs.RenderAnimation.__name__: bool_to_str(  # type: ignore[attr-defined]
+                    self.parent.render_animation_widget.isChecked()
+                ),
+                attrs.RegionLeft.__name__: int(  # type: ignore[attr-defined]
+                    self.parent.tiles_in_x_widget.value()
+                ),
+                attrs.RegionRight.__name__: int(  # type: ignore[attr-defined]
+                    self.parent.tiles_in_x_widget.value()
+                ),
+                attrs.RegionBottom.__name__: int(  # type: ignore[attr-defined]
+                    self.parent.tiles_in_y_widget.value()
+                ),
+                attrs.RegionTop.__name__: int(  # type: ignore[attr-defined]
+                    self.parent.tiles_in_y_widget.value()
+                ),
+                attrs.RenderQuality.__name__: str(  # type: ignore[attr-defined]
+                    self.parent.render_quality_widget.currentText()
+                ),
+                attrs.SSQuality.__name__: str(  # type: ignore[attr-defined]
+                    self.parent.ss_quality_widget.currentText()
+                ),
+                attrs.SceneFile.__name__: str(get_scene_full_path()),  # type: ignore[attr-defined]
+                attrs.SequenceName.__name__: str(  # type: ignore[attr-defined]
+                    self.parent.sequence_name_widget.text()
+                ),
+                attrs.SubmitDependentAssemblyJob.__name__: bool_to_str(  # type: ignore[attr-defined]
+                    self.parent.submit_dependent_assembly_widget.isChecked()
+                ),
+                attrs.TonemapHDR.__name__: bool_to_str(False),  # type: ignore[attr-defined]
+                attrs.View.__name__: str(  # type: ignore[attr-defined]
+                    self.parent.render_view_widget.currentText()
+                ),
+            }
+        )

--- a/src/deadline/vred_submitter/ui/components/scene_settings_widget.py
+++ b/src/deadline/vred_submitter/ui/components/scene_settings_widget.py
@@ -1,0 +1,612 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Defines the UI design for top-level scene-specific render settings ("Job-specific settings")
+Acts as the main control point for branching out these responsibilities to other classes:
+    - handling of Qt callbacks for UI elements
+    - populating VRED runtime-level values into UI elements
+"""
+
+from itertools import count
+from typing import Iterator, Type
+
+from ...data_classes import RenderSubmitterUISettings
+from ...qt_components import AutoSizedComboBox, AutoSizedButton, CustomGroupBox
+from ...utils import iterator_value
+from .constants import Constants
+from .scene_settings_callbacks import SceneSettingsCallbacks
+from .scene_settings_populator import SceneSettingsPopulator
+
+from PySide6.QtCore import Qt, QEvent
+from PySide6.QtGui import QDoubleValidator, QIntValidator
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QSpinBox,
+    QWidget,
+    QVBoxLayout,
+)
+
+
+class SceneSettingsWidget(QWidget):
+    """Represents a widget containing top-level scene-specific render settings ("Job-specific settings")"""
+
+    DEFAULT_WIDGET_ALIGNMENT = Qt.AlignLeft | Qt.AlignTop
+
+    def __init__(self, initial_settings: RenderSubmitterUISettings, parent: QWidget = None):
+        """
+        Builds the UI, connects UI elements to their respective callbacks, initializes a UI value populator.
+        param: initial_settings: maintains values for all render submission parameters.
+        param: parent: parent widget for this UI component.
+        """
+        super().__init__(parent=parent)
+        self.init_complete = False
+        self.parent = parent
+        self._build_ui()
+        self.callbacks = SceneSettingsCallbacks(self)
+        self.parent.installEventFilter(self)
+        self.populator = SceneSettingsPopulator(self, initial_settings)
+        self.init_complete = True
+
+    def eventFilter(self, obj, event):
+        """
+        Override to intercept events for the parent dialog; handles the close event by de-registering
+        past registered callbacks. Other events are passed through to the default handler.
+        param: obj: the object that triggered the event
+        param: event: event: that was triggered
+        return: False for close events; super().eventFilter for all other events
+        """
+        if obj == self.parent and event.type() == QEvent.Close:
+            self.callbacks.deregister_all_callbacks()
+            # Let the event continue to be processed
+            return False
+        return super().eventFilter(obj, event)
+
+    def _build_ui(self) -> None:
+        """
+        High-level routine for building the render settings user interface that comprises "Job-specific settings"
+        content. (It will be embedded under the "Job-specific settings" tab of the standard Deadline Cloud dialog.)
+
+        Note: UI elements (defined later) need to be synchronized with those exposed in template.yaml file. This
+        is necessary because callback functions, runtime value injection, and VRED-specific personalization needs to
+        access (and be applied to) UI elements. Remember to also synchronize constraints on values.
+        """
+        # The main layout contains group box-based sections
+        layout_main = self._create_main_layout_with_sections()
+        # A grid layout pairs with each of those sections and parents to matching layouts
+        grid_layout_general = QGridLayout()
+        grid_layout_render = QGridLayout()
+        grid_layout_sequencer = QGridLayout()
+        grid_layout_tiling = QGridLayout()
+        layout_main.addLayout(grid_layout_general)
+        self.group_box_render_options.layout().addLayout(grid_layout_render)
+        self.group_box_sequencer_options.layout().addLayout(grid_layout_sequencer)
+        self.group_box_tiling_settings.layout().addLayout(grid_layout_tiling)
+        # Create lower-level UI controls for each group. Keep the UI elements positioned relatively with a row counter.
+        row_counter = count()
+        self._build_general_options(grid_layout_general, row_counter)
+        self._build_render_options(grid_layout_render, row_counter)
+        self._build_sequencer_options(grid_layout_sequencer, row_counter)
+        self._build_tiling_settings(grid_layout_tiling, row_counter)
+
+    def _create_main_layout_with_sections(self) -> QVBoxLayout:
+        """
+        Create the main layout, adding group boxes for main sections.
+        return: the main layout
+        """
+        layout_main = QVBoxLayout(self)
+        self.group_box_render_options = CustomGroupBox(Constants.SECTION_RENDER_OPTIONS)
+        self.group_box_sequencer_options = CustomGroupBox(Constants.SECTION_SEQUENCER_OPTIONS)
+        self.group_box_tiling_settings = CustomGroupBox(Constants.SECTION_TILING_SETTINGS)
+        for group_box in [
+            self.group_box_render_options,
+            self.group_box_sequencer_options,
+            self.group_box_tiling_settings,
+        ]:
+            group_box.setLayout(QVBoxLayout())
+            layout_main.addWidget(group_box, self.DEFAULT_WIDGET_ALIGNMENT)
+        return layout_main
+
+    def _build_general_options(self, grid_layout: QGridLayout, row_counter: Iterator[int]) -> None:
+        """
+        Build general options section with UI elements defined below.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        """
+        self.render_job_type_label = QLabel(Constants.JOB_TYPE_LABEL)
+        self.render_job_type_label.setToolTip(Constants.JOB_TYPE_LABEL_DESCRIPTION)
+        self.render_job_type_widget = AutoSizedComboBox()
+        job_type_layout = QHBoxLayout()
+        job_type_layout.addWidget(self.render_job_type_label)
+        job_type_layout.addWidget(self.render_job_type_widget)
+        grid_layout.addLayout(job_type_layout, next(row_counter), 0, self.DEFAULT_WIDGET_ALIGNMENT)
+
+    def _build_render_options(self, grid_layout: QGridLayout, row_counter: Iterator[int]) -> None:
+        """
+        Build Render Options section with UI elements defined below.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        """
+        self._add_render_output_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
+        self.render_view_widget = self._add_label_and_widget(
+            grid_layout,
+            row_counter,
+            self.DEFAULT_WIDGET_ALIGNMENT,
+            Constants.RENDER_VIEW_LABEL,
+            Constants.RENDER_VIEW_LABEL_DESCRIPTION,
+            AutoSizedComboBox,
+        )
+        self._add_image_size_preset_controls(
+            grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT
+        )
+        self._add_image_size_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
+        self._add_printing_size_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
+        self._add_resolution_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
+        self._add_render_animation_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
+        self.render_quality_widget = self._add_label_and_widget(
+            grid_layout,
+            row_counter,
+            self.DEFAULT_WIDGET_ALIGNMENT,
+            Constants.RENDER_QUALITY_LABEL,
+            Constants.RENDER_QUALITY_LABEL_DESCRIPTION,
+            AutoSizedComboBox,
+        )
+        self.dlss_quality_widget = self._add_label_and_widget(
+            grid_layout,
+            row_counter,
+            self.DEFAULT_WIDGET_ALIGNMENT,
+            Constants.DLSS_QUALITY_LABEL,
+            Constants.DLSS_QUALITY_LABEL_DESCRIPTION,
+            AutoSizedComboBox,
+        )
+        self.ss_quality_widget = self._add_label_and_widget(
+            grid_layout,
+            row_counter,
+            self.DEFAULT_WIDGET_ALIGNMENT,
+            Constants.SS_QUALITY_LABEL,
+            Constants.SS_QUALITY_LABEL_DESCRIPTION,
+            AutoSizedComboBox,
+        )
+        self._add_animation_type_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
+        self._add_animation_clip_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
+        self.use_clip_range_widget = QCheckBox(Constants.USE_CLIP_RANGE_LABEL)
+        self.use_clip_range_widget.setToolTip(Constants.USE_CLIP_RANGE_LABEL_DESCRIPTION)
+        grid_layout.addWidget(
+            self.use_clip_range_widget, next(row_counter), 0, self.DEFAULT_WIDGET_ALIGNMENT
+        )
+        self._add_frame_range_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
+        self._add_frames_per_task_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
+
+    def _build_sequencer_options(
+        self, grid_layout: QGridLayout, row_counter: Iterator[int]
+    ) -> None:
+        """
+        Build sequencer options section with UI elements defined below.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        """
+
+        self.sequence_name_label = QLabel(Constants.SEQUENCE_NAME_LABEL)
+        self.sequence_name_label.setToolTip(Constants.SEQUENCE_NAME_LABEL_DESCRIPTION)
+        grid_layout.addWidget(
+            self.sequence_name_label, iterator_value(row_counter), 0, self.DEFAULT_WIDGET_ALIGNMENT
+        )
+        self.sequence_name_widget = QLineEdit("")
+        self.sequence_name_widget.setFixedWidth(Constants.LONG_TEXT_ENTRY_WIDTH)
+        grid_layout.addWidget(
+            self.sequence_name_widget, iterator_value(row_counter), 1, self.DEFAULT_WIDGET_ALIGNMENT
+        )
+
+    def _build_tiling_settings(self, grid_layout: QGridLayout, row_counter: Iterator[int]) -> None:
+        """
+        Build tiling settings section with UI elements defined below.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        """
+
+        self._add_region_rendering_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
+        self._add_tiles_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
+        self._add_assembly_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
+        self._add_abort_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
+        self._add_assemble_over_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
+        self._add_background_image_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
+
+    def _add_label_and_widget(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+        label_text: str,
+        tooltip: str,
+        widget_cls: Type[QWidget],
+    ) -> QWidget:
+        """
+        Helper method to add a label and widget pair to a grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        param: label_text: text for the label
+        param: widget_cls: the type of QWidget-based widget to create and add to the grid layout
+        return: the created widget instance based on widget_cls
+        """
+        label = QLabel(label_text)
+        label.setToolTip(tooltip)
+        new_widget = widget_cls()
+        grid_layout.addWidget(label, iterator_value(row_counter), 0, alignment)
+        grid_layout.addWidget(new_widget, next(row_counter), 1, alignment)
+        return new_widget
+
+    def _add_render_output_controls(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+    ) -> None:
+        """
+        Add render output UI elements to the grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        """
+        self.render_output_label = QLabel(Constants.RENDER_OUTPUT_LABEL)
+        self.render_output_label.setToolTip(Constants.RENDER_OUTPUT_LABEL_DESCRIPTION)
+        grid_layout.addWidget(self.render_output_label, iterator_value(row_counter), 0, alignment)
+        self.render_output_widget = QLineEdit("")
+        self.render_output_widget.setFixedWidth(Constants.VERY_LONG_TEXT_ENTRY_WIDTH)
+        self.render_output_button = AutoSizedButton(Constants.ELLIPSIS_LABEL)
+        render_output_layout = QHBoxLayout()
+        render_output_layout.addWidget(self.render_output_widget)
+        render_output_layout.addWidget(self.render_output_button)
+        grid_layout.addLayout(render_output_layout, next(row_counter), 1, alignment)
+
+    def _add_image_size_preset_controls(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+    ) -> None:
+        """
+        Add image size preset UI elements to the grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        """
+        self.image_size_presets_label = QLabel(Constants.IMAGE_SIZE_PRESETS_LABEL)
+        self.image_size_presets_label.setToolTip(Constants.IMAGE_SIZE_PRESETS_LABEL_DESCRIPTION)
+        grid_layout.addWidget(
+            self.image_size_presets_label, iterator_value(row_counter), 0, alignment
+        )
+        self.image_size_presets_widget = AutoSizedComboBox()
+        grid_layout.addWidget(self.image_size_presets_widget, next(row_counter), 1, alignment)
+
+    def _add_image_size_controls(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+    ) -> None:
+        """
+        Add image size UI elements to the grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        """
+        self.image_size_label = QLabel(Constants.IMAGE_SIZE_LABEL)
+        self.image_size_label.setToolTip(Constants.IMAGE_SIZE_LABEL_DESCRIPTION)
+        grid_layout.addWidget(self.image_size_label, iterator_value(row_counter), 0, alignment)
+        self.image_size_x_widget = QLineEdit("")
+        self.image_size_x_widget.setFixedWidth(Constants.SHORT_TEXT_ENTRY_WIDTH)
+        self.image_size_y_widget = QLineEdit("")
+        self.image_size_y_widget.setFixedWidth(Constants.SHORT_TEXT_ENTRY_WIDTH)
+        image_size_layout = QHBoxLayout()
+        image_size_layout.addWidget(self.image_size_x_widget)
+        image_size_layout.addWidget(self.image_size_y_widget)
+        grid_layout.addLayout(image_size_layout, next(row_counter), 1, alignment)
+        image_size_validator = QIntValidator(
+            Constants.MIN_IMAGE_DIMENSION, Constants.MAX_IMAGE_DIMENSION
+        )
+        self.image_size_x_widget.setValidator(image_size_validator)
+        self.image_size_y_widget.setValidator(image_size_validator)
+
+    def _add_printing_size_controls(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+    ) -> None:
+        """
+        Add printing size UI elements to the grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        """
+        self.printing_size_label = QLabel(Constants.PRINTING_SIZE_LABEL)
+        self.printing_size_label.setToolTip(Constants.PRINTING_SIZE_LABEL_DESCRIPTION)
+        grid_layout.addWidget(self.printing_size_label, iterator_value(row_counter), 0, alignment)
+        self.printing_size_x_widget = QLineEdit("")
+        self.printing_size_x_widget.setFixedWidth(Constants.SHORT_TEXT_ENTRY_WIDTH)
+        self.printing_size_y_widget = QLineEdit("")
+        self.printing_size_y_widget.setFixedWidth(Constants.SHORT_TEXT_ENTRY_WIDTH)
+        printing_size_layout = QHBoxLayout()
+        printing_size_layout.addWidget(self.printing_size_x_widget)
+        printing_size_layout.addWidget(self.printing_size_y_widget)
+        grid_layout.addLayout(printing_size_layout, next(row_counter), 1, alignment)
+        printing_size_validator = QDoubleValidator(
+            Constants.MIN_IMAGE_DIMENSION,
+            Constants.MAX_IMAGE_DIMENSION,
+            Constants.PRINTING_PRECISION_DIGITS_COUNT,
+        )
+        self.printing_size_x_widget.setValidator(printing_size_validator)
+        self.printing_size_y_widget.setValidator(printing_size_validator)
+
+    def _add_resolution_controls(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+    ) -> None:
+        """
+        Add resolution UI elements to the grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        """
+        self.resolution_label = QLabel(Constants.RESOLUTION_LABEL)
+        self.resolution_label.setToolTip(Constants.RESOLUTION_LABEL_DESCRIPTION)
+        grid_layout.addWidget(self.resolution_label, iterator_value(row_counter), 0, alignment)
+        self.resolution_widget = QLineEdit("")
+        self.resolution_widget.setFixedWidth(Constants.SHORT_TEXT_ENTRY_WIDTH)
+        grid_layout.addWidget(self.resolution_widget, next(row_counter), 1, alignment)
+        self.resolution_widget.setValidator(QIntValidator(Constants.MIN_DPI, Constants.MAX_DPI))
+
+    def _add_render_animation_controls(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+    ) -> None:
+        """
+        Add render animation and GPU ray tracing UI elements to the grid layout."""
+        self.render_animation_widget = QCheckBox(Constants.RENDER_ANIMATION_LABEL)
+        self.render_animation_widget.setToolTip(Constants.RENDER_ANIMATION_LABEL_DESCRIPTION)
+        grid_layout.addWidget(
+            self.render_animation_widget, iterator_value(row_counter), 0, alignment
+        )
+        self.gpu_ray_tracing_widget = QCheckBox(Constants.USE_GPU_RAY_TRACING_LABEL)
+        self.gpu_ray_tracing_widget.setToolTip(Constants.USE_GPU_RAY_TRACING_LABEL_DESCRIPTION)
+        grid_layout.addWidget(self.gpu_ray_tracing_widget, next(row_counter), 1, alignment)
+
+    def _add_animation_type_controls(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+    ) -> None:
+        """
+        Add animation type UI elements to the grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        """
+        self.animation_type_label = QLabel(Constants.ANIMATION_TYPE_LABEL)
+        self.animation_type_label.setToolTip(Constants.ANIMATION_TYPE_LABEL_DESCRIPTION)
+        grid_layout.addWidget(self.animation_type_label, iterator_value(row_counter), 0, alignment)
+        self.animation_type_widget = AutoSizedComboBox()
+        grid_layout.addWidget(self.animation_type_widget, next(row_counter), 1, alignment)
+
+    def _add_animation_clip_controls(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+    ) -> None:
+        """
+        Add animation clip UI elements to the grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        """
+        self.animation_clip_label = QLabel(Constants.ANIMATION_CLIP_LABEL)
+        self.animation_clip_label.setToolTip(Constants.ANIMATION_CLIP_LABEL_DESCRIPTION)
+        grid_layout.addWidget(self.animation_clip_label, iterator_value(row_counter), 0, alignment)
+        self.animation_clip_widget = AutoSizedComboBox()
+        self.animation_clip_widget.setFixedWidth(Constants.MODERATE_TEXT_ENTRY_WIDTH)
+        grid_layout.addWidget(self.animation_clip_widget, next(row_counter), 1, alignment)
+
+    def _add_frame_range_controls(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+    ) -> None:
+        """
+        Add frame range UI elements to the grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        """
+        self.frame_range_label = QLabel(Constants.FRAME_RANGE_LABEL)
+        self.frame_range_label.setToolTip(Constants.FRAME_RANGE_LABEL_DESCRIPTION)
+        grid_layout.addWidget(self.frame_range_label, iterator_value(row_counter), 0, alignment)
+        self.frame_range_widget = QLineEdit("")
+        self.frame_range_widget.setFixedWidth(Constants.LONG_TEXT_ENTRY_WIDTH)
+        grid_layout.addWidget(self.frame_range_widget, next(row_counter), 1, alignment)
+
+    def _add_frames_per_task_controls(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+    ) -> None:
+        """
+        Add frames per task UI elements to the grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        """
+        self.frames_per_task_label = QLabel(Constants.FRAMES_PER_TASK_LABEL)
+        self.frames_per_task_label.setToolTip(Constants.FRAMES_PER_TASK_LABEL_DESCRIPTION)
+        grid_layout.addWidget(self.frames_per_task_label, iterator_value(row_counter), 0, alignment)
+        self.frames_per_task_widget = QSpinBox()
+        self.frames_per_task_widget.setFixedWidth(Constants.SHORT_TEXT_ENTRY_WIDTH)
+        grid_layout.addWidget(self.frames_per_task_widget, next(row_counter), 1, alignment)
+        self.frames_per_task_widget.setMinimum(Constants.MIN_FRAMES_PER_TASK)
+        self.frames_per_task_widget.setMaximum(Constants.MAX_FRAMES_PER_TASK)
+
+    def _add_region_rendering_controls(
+        self, grid_layout: QGridLayout, row_counter: Iterator[int], alignment: Qt.Alignment
+    ) -> None:
+        """
+        Add region rendering UI elements to the grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        """
+        self.enable_region_rendering_widget = QCheckBox(Constants.ENABLE_REGION_RENDERING_LABEL)
+        self.enable_region_rendering_widget.setToolTip(
+            Constants.ENABLE_REGION_RENDERING_LABEL_DESCRIPTION
+        )
+        grid_layout.addWidget(
+            self.enable_region_rendering_widget, next(row_counter), 0, 1, 1, alignment
+        )
+
+    def _add_tiles_controls(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+    ) -> None:
+        """
+        Add tiles in X and Y UI elements to the grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        """
+        self.tiles_in_x_label = QLabel(Constants.TILES_IN_X_LABEL)
+        self.tiles_in_x_label.setToolTip(Constants.TILES_IN_X_LABEL_DESCRIPTION)
+        self.tiles_in_x_widget = QSpinBox()
+        self.tiles_in_x_widget.setFixedWidth(Constants.SHORT_TEXT_ENTRY_WIDTH)
+        tiles_in_x_layout = QHBoxLayout()
+        tiles_in_x_layout.addWidget(self.tiles_in_x_label)
+        tiles_in_x_layout.addWidget(self.tiles_in_x_widget)
+        grid_layout.addLayout(tiles_in_x_layout, iterator_value(row_counter), 0, alignment)
+        self.tiles_in_y_label = QLabel(Constants.TILES_IN_Y_LABEL)
+        self.tiles_in_y_label.setToolTip(Constants.TILES_IN_Y_LABEL_DESCRIPTION)
+        self.tiles_in_y_widget = QSpinBox()
+        self.tiles_in_y_widget.setFixedWidth(Constants.SHORT_TEXT_ENTRY_WIDTH)
+        tiles_in_y_layout = QHBoxLayout()
+        tiles_in_y_layout.addWidget(self.tiles_in_y_label)
+        tiles_in_y_layout.addWidget(self.tiles_in_y_widget)
+        grid_layout.addLayout(tiles_in_y_layout, next(row_counter), 1, alignment)
+        self.tiles_in_x_widget.setMinimum(Constants.MIN_TILES_PER_DIMENSION)
+        self.tiles_in_x_widget.setMaximum(Constants.MAX_TILES_PER_DIMENSION)
+        self.tiles_in_y_widget.setMinimum(Constants.MIN_TILES_PER_DIMENSION)
+        self.tiles_in_y_widget.setMaximum(Constants.MAX_TILES_PER_DIMENSION)
+
+    def _add_assembly_controls(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+    ) -> None:
+        """
+        Add assembly job UI elements to the grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        """
+        self.submit_dependent_assembly_widget = QCheckBox(
+            Constants.SUBMIT_DEPENDENT_ASSEMBLY_JOB_LABEL
+        )
+        self.submit_dependent_assembly_widget.setToolTip(
+            Constants.SUBMIT_DEPENDENT_ASSEMBLY_JOB_LABEL_DESCRIPTION
+        )
+        grid_layout.addWidget(
+            self.submit_dependent_assembly_widget, iterator_value(row_counter), 0, alignment
+        )
+        self.cleanup_tiles_widget = QCheckBox(Constants.CLEAN_UP_TILES_AFTER_ASSEMBLY_LABEL)
+        self.cleanup_tiles_widget.setToolTip(
+            Constants.SUBMIT_DEPENDENT_ASSEMBLY_JOB_LABEL_DESCRIPTION
+        )
+        grid_layout.addWidget(self.cleanup_tiles_widget, next(row_counter), 1, alignment)
+
+    def _add_abort_controls(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+    ) -> None:
+        """
+        Add abort handling UI elements to the grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        """
+        self.abort_on_missing_tiles_widget = QCheckBox(Constants.ABORT_ON_MISSING_TILES_LABEL)
+        self.abort_on_missing_tiles_widget.setToolTip(
+            Constants.ABORT_ON_MISSING_TILES_LABEL_DESCRIPTION
+        )
+        grid_layout.addWidget(
+            self.abort_on_missing_tiles_widget, iterator_value(row_counter), 0, alignment
+        )
+        self.abort_on_missing_background_widget = QCheckBox(
+            Constants.ABORT_ON_MISSING_BACKGROUND_LABEL
+        )
+        self.abort_on_missing_background_widget.setToolTip(
+            Constants.ABORT_ON_MISSING_BACKGROUND_LABEL_DESCRIPTION
+        )
+        grid_layout.addWidget(
+            self.abort_on_missing_background_widget, next(row_counter), 1, alignment
+        )
+
+    def _add_assemble_over_controls(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+    ) -> None:
+        """
+        Add assemble over UI elements to the grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        """
+        self.assemble_over_label = QLabel(Constants.ASSEMBLE_OVER_LABEL)
+        self.assemble_over_label.setToolTip(Constants.ASSEMBLE_OVER_LABEL_DESCRIPTION)
+        grid_layout.addWidget(self.assemble_over_label, iterator_value(row_counter), 0, alignment)
+        self.assemble_over_widget = AutoSizedComboBox()
+        grid_layout.addWidget(self.assemble_over_widget, next(row_counter), 1, alignment)
+
+    def _add_background_image_controls(
+        self,
+        grid_layout: QGridLayout,
+        row_counter: Iterator[int],
+        alignment: Qt.Alignment,
+    ) -> None:
+        """
+        Add background image UI elements to the grid layout.
+        param: grid_layout: the grid layout to which UI elements are added
+        param: row_counter: tracks row number that UI elements added
+        param: alignment: alignment for the label and widget
+        """
+        self.backgroundImageLabel = QLabel(Constants.BACKGROUND_IMAGE_LABEL)
+        self.backgroundImageLabel.setToolTip(Constants.BACKGROUND_IMAGE_LABEL_DESCRIPTION)
+        grid_layout.addWidget(self.backgroundImageLabel, iterator_value(row_counter), 0, alignment)
+        self.background_image_widget = QLineEdit("")
+        self.background_image_widget.setFixedWidth(Constants.LONG_TEXT_ENTRY_WIDTH)
+        self.background_image_button = AutoSizedButton(Constants.ELLIPSIS_LABEL)
+        background_image_layout = QHBoxLayout()
+        background_image_layout.addWidget(self.background_image_widget)
+        background_image_layout.addWidget(self.background_image_button)
+        grid_layout.addLayout(background_image_layout, iterator_value(row_counter), 1, alignment)
+
+    def update_settings(self, settings: RenderSubmitterUISettings) -> None:
+        """
+        Update a scene settings object with the latest UI values using the OpenJD typing convention.
+        Note: this callback is invoked by the Deadline Cloud API; callback is unreferenced in submitter code.
+        param: setting : maintains values for all render submission parameters
+        """
+        self.populator.update_settings_callback(settings)


### PR DESCRIPTION
- Defines the UI design for top-level scene-specific render settings ("Job-specific settings")
- Acts as the main control point for branching out these responsibilities to other classes:
    - handling of Qt callbacks for UI elements
    - populating VRED runtime-level values into UI elements
- Includes a Constants class that is UI specific. Depends on callback and UI logic handling are components that will be included separately.
- Enforces restricted values on frames per task option and tiling parameters
- Introduces class (SceneSettingsCallbacks) that implements backend callbacks and UX interaction logic for the UI within "Job-specific settings"
- Introduces a class (SceneSettingsPopulator) that provides backend UI value population and interpretation for the UI within "Job-specific settings"
	- SceneSettingsCallbacks and SceneSettingsPopulator have access to a SceneSettingsWidget instance (via parent reference) as a way to farm out responsibilities from SceneSettingsWidget.

![image](https://github.com/user-attachments/assets/ed1eba0d-64b2-40ab-8018-fddaf7071d63)

### What was the problem/requirement? (What/Why)

Need to design a Qt Widget to represent Job-specific settings in a modular fashion.

### What was the solution? (How)

Current module that defines that widget and branches out responsibilities to other classes that will have access to this class via parent reference.

### What is the impact of this change?

None.

### How was this change tested?

Exercising individual UI elements and validating with UX team member.

### Was this change documented?

It will be.

*delete text starting here*
- Did you update all relevant docstrings for Python functions that you modified?
- Should the README.md, DEVELOPMENT.md, or other documents in the repository's docs/ directory be updated along with your change?
- Should the schema files for the adaptor's init-data or run-data be updated?
*delete text ending here*

### Is this a breaking change?

No

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
