### PR TITLE
feat: utilities modules (for invoking VRED API, Qt, and general purpose helper methods)

### DIFF
--- a/src/deadline/vred_submitter/qt_components.py
+++ b/src/deadline/vred_submitter/qt_components.py
@@ -1,0 +1,199 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Provides Qt-based Custom UI Controls"""
+
+from typing import Optional
+
+from .constants import Constants
+
+from PySide6.QtCore import QEvent, Qt, QSize
+from PySide6.QtGui import QFontMetrics
+from PySide6.QtWidgets import (
+    QComboBox,
+    QFileDialog,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QSpacerItem,
+    QWidget,
+)
+
+
+class CustomGroupBox(QGroupBox):
+    """
+    A QGroupBox that has a custom stylesheet applied
+    """
+
+    def __init__(self, text: str = "", parent: QGroupBox = None):
+        """
+        param: text: the text to be displayed in the group box's title.
+        param: parent: the parent widget
+        """
+        super().__init__(text, parent)
+        self.setStyleSheet(Constants.QT_GROUP_BOX_STYLESHEET)
+
+
+class AutoSizedButton(QPushButton):
+    """
+    A QPushButton that automatically adjusts its size based on its text content.
+    """
+
+    def __init__(self, text: str = "", parent: QPushButton = None):
+        """
+        param: text: the text to be displayed on the push button.
+        param: parent: the parent widget
+        """
+        super().__init__(text, parent)
+        self.setMinimumWidth(self.calculate_width())
+
+    def calculate_width(self) -> int:
+        """
+        Calculate the width of the button based on its text content.
+        return: the calculated width
+        """
+        if not self.text():
+            return 0
+        text_width = int(QFontMetrics(self.font()).horizontalAdvance(self.text()))
+        return int(
+            (text_width + Constants.PUSH_BUTTON_PADDING_PIXELS) / Constants.PUSH_BUTTON_WIDTH_FACTOR
+        )
+
+    def sizeHint(self) -> QSize:
+        """
+        Overrides to adjust the width of the button.
+        return: the size hint
+        """
+        super().sizeHint().setWidth(self.calculate_width())
+        return super().sizeHint()
+
+
+class AutoSizedComboBox(QComboBox):
+    """
+    A QComboBox that automatically adjusts its size based on the maximum length of its entries.
+    """
+
+    def __init__(self, parent: QComboBox = None):
+        """
+        param: parent: the parent widget
+        """
+
+        super().__init__(parent)
+        # Perform automatic resizing when entries are changed
+        self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
+        self.model().rowsInserted.connect(self.adjust_size_callback)
+        self.model().rowsRemoved.connect(self.adjust_size_callback)
+
+    def adjust_size_callback(self) -> None:
+        """
+        Adjust the size of the combo box based on the maximum length of its entries.
+        """
+        # Avoid shrinking and find the widest entry
+        self.setMinimumWidth(self.sizeHint().width())
+        metrics = QFontMetrics(self.font())
+        max_width = 0
+        for i in range(self.count()):
+            width = metrics.horizontalAdvance(self.itemText(i))
+            max_width = max(max_width, width)
+        # Add padding for dropdown arrow and frame
+        max_width = max(max_width + Constants.COMBO_BOX_PADDING, Constants.COMBO_BOX_MIN_WIDTH)
+        self.setFixedWidth(max_width)
+        # Popup view should also be sufficiently wide
+        if self.view():
+            self.view().setMinimumWidth(max_width)
+
+
+class AutoSizingMessageBox(QMessageBox):
+    """
+    A QMessageBox that automatically adjusts its size based on its text content.
+    """
+
+    def __init__(self, parent):
+        """
+        param: parent: the parent widget
+        """
+        super().__init__(parent)
+        # Rich text improves formatting
+        self.setTextFormat(Qt.TextFormat.RichText)
+        self.setMinimumWidth(Constants.MESSAGE_BOX_MIN_WIDTH)
+        self.setMaximumWidth(Constants.MESSAGE_BOX_MAX_WIDTH)
+        self.setSizePolicy(self.sizePolicy().horizontalPolicy(), self.sizePolicy().verticalPolicy())
+
+    def resizeEvent(self, event: QEvent) -> None:
+        """
+        Overrides resize event handler to adjust the layout.
+        param: event: resize event
+        """
+        result = super().resizeEvent(event)
+        # Horizontal spacer helps to adjust layout width
+        layout = self.layout()
+        if layout is not None and isinstance(layout, QGridLayout):
+            spacer = QSpacerItem(Constants.MESSAGE_BOX_SPACER_PREFERRED_WIDTH, 0)
+            layout.addItem(spacer, layout.rowCount(), 0, 1, layout.columnCount())
+        return result
+
+
+class FileSearchLineEdit(QWidget):
+    """
+    A widget containing a QLineEdit and QPushButton object for specifying a file or directory.
+    """
+
+    def __init__(
+        self, file_format: str = "", directory_only: bool = False, parent: Optional[QWidget] = None
+    ):
+        """
+        param: file_format: the file format from which to filter
+        param: directory_only: whether to allow directory selection only
+        param: parent: the parent widget
+        raise: ValueError: file_format missing when directory_only specified
+        """
+        super().__init__(parent=parent)
+        if directory_only and file_format:
+            raise ValueError
+        self.file_format = file_format
+        self.directory_only = directory_only
+        self.path_text_box = QLineEdit(self)
+        self.button = QPushButton(Constants.ELLIPSIS_LABEL, parent=self)
+        self.setup()
+
+    def setup(self) -> None:
+        """
+        Sets up the layout of the QLineEdit and push button controls.
+        """
+        self.path_text_box.setFixedWidth(Constants.VERY_LONG_TEXT_ENTRY_WIDTH)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.button.setMaximumSize(
+            QSize(Constants.PUSH_BUTTON_MAXIMUM_WIDTH, Constants.PUSH_BUTTON_MAXIMUM_HEIGHT)
+        )
+        self.button.clicked.connect(self.common_file_dialog_callback)
+        layout.addWidget(self.path_text_box)
+        layout.addWidget(self.button)
+
+    def common_file_dialog_callback(self) -> None:
+        """
+        Open a common file dialog for selecting a file or directory (depending on self.directory_only) and
+        put its path (if specified) into a QLineEdit text box (self.path_text_box) for future use.
+        """
+        if self.directory_only:
+            new_path_str = QFileDialog.getExistingDirectory(
+                self,
+                Constants.SELECT_DIRECTORY_PROMPT,
+                self.path_text_box.text(),
+                QFileDialog.ShowDirsOnly | QFileDialog.DontResolveSymlinks,
+            )
+        else:
+            new_path_str = QFileDialog.getOpenFileName(
+                self, Constants.SELECT_FILE_PROMPT, self.path_text_box.text()
+            )
+
+        if new_path_str:
+            self.path_text_box.setText(new_path_str)
+
+    def text(self) -> str:
+        """
+        return: the path text from the internal QLineEdit control
+        """
+        return self.path_text_box.text()

--- a/src/deadline/vred_submitter/qt_utils.py
+++ b/src/deadline/vred_submitter/qt_utils.py
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Qt-based Convenience/Utility Functions"""
+
+from .qt_components import AutoSizingMessageBox
+
+from PySide6.QtWidgets import QMessageBox
+
+
+def show_qt_ok_message_dialog(title: str, message: str) -> None:
+    """
+    Display a modal information dialog box containing an OK button.
+    param: title: the title of the dialog window
+    param: message: the message to display in the dialog
+    """
+    message_box = AutoSizingMessageBox(parent=None)
+    message_box.setWindowTitle(title)
+    message_box.setText(message)
+    message_box.setIcon(QMessageBox.Icon.Information)
+    message_box.setStandardButtons(QMessageBox.StandardButton.Ok)
+    message_box.exec()
+
+
+def get_qt_yes_no_dialog_prompt_result(title: str, message: str, default_to_yes: bool) -> bool:
+    """
+    Display a modal question dialog box containing Yes/No buttons and return the user's choice.
+    param: title: the title of the dialog window
+    param: message: the question to display in the dialog
+    param: default_to_yes: if True, the "Yes" button will be the default selection; else "No" button
+    return: True if the user selected the "Yes" button; False otherwise
+    """
+    message_box = AutoSizingMessageBox(parent=None)
+    message_box.setWindowTitle(title)
+    message_box.setText(message)
+    message_box.setIcon(QMessageBox.Icon.Question)
+    message_box.setStandardButtons(QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
+    default_button = (
+        QMessageBox.StandardButton.Yes if default_to_yes else QMessageBox.StandardButton.No
+    )
+    message_box.setDefaultButton(default_button)
+    return message_box.exec() == QMessageBox.StandardButton.Yes

--- a/src/deadline/vred_submitter/utils.py
+++ b/src/deadline/vred_submitter/utils.py
@@ -1,0 +1,203 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""General Convenience/Utility Functions"""
+
+import math
+import time
+import yaml
+
+from .constants import Constants
+
+from functools import wraps
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterator, List, TypeVar, Union
+from yaml.parser import ParserError
+from yaml.scanner import ScannerError
+
+TypeName = TypeVar("TypeName")
+
+
+class NamedValue:
+    """
+    Wrapper class to store a value along with its name.
+    It allows primitive values (which don't normally have a __name__ attribute) to store their identifier name.
+    """
+
+    def __init__(self, name: str, value: Any) -> None:
+        """
+        Initialize a NamedValue instance.
+        param: name : the name to associate with the value.
+        param: value : the value to be wrapped.
+        """
+        self.value = value
+        self.__name__ = name
+
+    def __repr__(self) -> str:
+        """
+        Returns a string representation of the NamedValue instance.
+        return: a string containing both a name and a value.
+        """
+        return f"NamedValue(name='{self.__name__}', value='{self.value}')"
+
+    def __eq__(self, other: Any) -> bool:
+        """
+        Compares this NamedValue with another value for equality.
+        param: other: the value to compare
+        return: True if the values are equal, False otherwise.
+        """
+        if isinstance(other, NamedValue):
+            return self.value == other.value
+        return self.value == other
+
+
+class DynamicKeyValueObject:
+    def __init__(self, data_dict: Dict[str, Any]) -> None:
+        """
+        Assigns attributes and values to this object that reflect the contents of data_dict
+        param: data_dict: attributes/properties and associated values
+        """
+        for k, v in data_dict.items():
+            named_value = NamedValue(name=k, value=v)
+            setattr(self, k, named_value)
+
+
+def timed_func(func: Callable[..., TypeName]) -> Callable[..., TypeName]:
+    """
+    Decorator that wraps a function for deducing performance timing
+    param: func: the function to be timed
+    return: wrapped function that prints timing information when called
+    """
+
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        start = time.perf_counter()
+        result = func(*args, **kwargs)
+        end = time.perf_counter()
+        elapsed = end - start
+        print(
+            f"func: {func.__name__} with args: {args}, kwargs: {kwargs}, took {elapsed:.3f} seconds"
+        )
+        return result
+
+    return wrapped
+
+
+def ceil(number: float, decimals: int) -> float:
+    """Rounds a number up to a specific decimal place.
+    param: number: the number to round up
+    param: decimals: the number of decimal places to round
+    raise: TypeError: if decimals isn't an integer
+    raise: ValueError: if decimals is negative
+    return: rounded number.
+    """
+    if not isinstance(decimals, int) or not isinstance(number, float):
+        raise TypeError
+    if decimals <= 0:
+        raise ValueError()
+    return math.ceil(number * (Constants.BASE_TEN**decimals)) / (Constants.BASE_TEN**decimals)
+
+
+def get_yaml_contents(file_path: str) -> Dict[str, Any]:
+    """
+    Read and parse contents of a YAML file.
+    param: file_path: path to the YAML file as string or Path object
+    raise: FileNotFoundError: If the specified file does not exist
+    raise: PermissionError: If the program lacks permission to read the file
+    raise: yaml.YAMLError: If the YAML content is malformed
+    raise: TypeError: If the YAML content is not a dictionary
+    return: parsed YAML contents
+    """
+    try:
+        path = Path(file_path)
+        if not path.is_file():
+            raise FileNotFoundError(f"{Constants.ERROR_YAML_NOT_FOUND}: {file_path}")
+        with path.open(Constants.READ_FLAG, encoding=Constants.UTF8_FLAG) as file_handle:
+            contents = yaml.safe_load(file_handle)
+        if not isinstance(contents, dict):
+            raise TypeError(f"{Constants.ERROR_YAML_OBJECT_NOT_FOUND}: {type(contents)}")
+        return contents
+    except (ParserError, ScannerError) as yaml_err:
+        raise yaml.YAMLError(
+            f"{Constants.ERROR_YAML_INVALID_FORMAT} {file_path}: {str(yaml_err)}"
+        ) from yaml_err
+    except PermissionError as perm_err:
+        raise PermissionError(f"{Constants.ERROR_FILE_PERMISSIONS_ISSUE} {file_path}") from perm_err
+    except Exception as exc:
+        raise RuntimeError(f"{Constants.ERROR_YAML_GENERAL_ERROR} {file_path}: {str(exc)}") from exc
+
+
+def is_number(string: str) -> bool:
+    """
+    Check if the provided string represents a number.
+    param: string: the string to check
+    return: True if the string represents a number, False otherwise
+    """
+    if not string:
+        return False
+    try:
+        float(string)
+    except (ValueError, TypeError):
+        return False
+    return True
+
+
+def is_all_numbers(strings: List[str]) -> bool:
+    """
+    Check if all provided strings represent numbers.
+    param: strings: list of strings to check
+    return: true if all provided strings represent numbers.
+    """
+    if not strings:
+        return False
+    for string in strings:
+        if not is_number(string):
+            return False
+    return True
+
+
+def is_numerically_defined(num: str) -> bool:
+    """
+    Check if the provided string represents a numerically defined value.
+    param: num: the numeric string to evaluate
+    return: True if the string represents a numerically defined value; False otherwise
+    """
+    return (
+        is_number(num)
+        and float(num) != float(Constants.POSITIVE_INFINITY)
+        and float(num) != float(Constants.NEGATIVE_INFINITY)
+        and float(num) != float(Constants.NAN)
+    )
+
+
+def iterator_value(counter: Iterator[int]) -> int:
+    """
+    Get the current value of an iterator counter.
+    param: counter: iterator counter
+    return: the current integral value of an iterator counter
+    """
+    return int(counter.__reduce__()[1][0])
+
+
+def bool_to_str(boolean: bool) -> str:
+    """
+    Convert a boolean value to its string representation.
+    param: boolean: boolean value to convert
+    return: "false" if boolean==False; else "true"
+    """
+    return str(boolean).lower()
+
+
+def clamp(
+    value: Union[int, float], min_val: Union[int, float], max_val: Union[int, float]
+) -> Union[int, float]:
+    """
+    Clamp a numeric value to be between (or at) min and max values, preserving the original type.
+    param: value: value to clamp
+    param: min_val: minimum value accepted
+    param: max_val: maximum value accepted
+    return: clamped value
+    """
+    result = max(min_val, min(value, max_val))
+    if isinstance(value, int) and isinstance(min_val, int) and isinstance(max_val, int):
+        return int(result)
+    return result

--- a/src/deadline/vred_submitter/vred_logger.py
+++ b/src/deadline/vred_submitter/vred_logger.py
@@ -8,7 +8,7 @@ import logging.handlers
 import os
 import tempfile
 
-import vrController  # pylint: disable=import-error
+import vrController
 
 
 class VREDConsoleHandler(logging.Handler):

--- a/src/deadline/vred_submitter/vred_utils.py
+++ b/src/deadline/vred_submitter/vred_utils.py
@@ -1,0 +1,312 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""VRED-specific Convenients/Utility Functions"""
+
+import os
+import re
+
+from typing import Dict, List, Tuple
+
+from .constants import Constants
+from .utils import is_numerically_defined
+
+from PySide6.QtCore import QObject
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import QDialog, QMainWindow, QToolBar, QToolButton
+
+from builtins import vrCameraService, vrFileIOService, vrMainWindow  # type: ignore[attr-defined]
+from vrAnimWidgets import getAnimClips, getAnimClipNodes, getCurrentFrame
+from vrController import getVredVersionYear
+from vrOSGWidget import getRenderWindowHeight, getRenderWindowWidth
+from vrRenderSettings import (
+    getRenderAnimation,
+    getRenderFilename,
+    getRenderFrameStep,
+    getRenderStartFrame,
+    getRenderStopFrame,
+)
+
+
+def assign_scene_transition_event(callback_function) -> None:
+    """
+    Connects scene transition events (new scene and project load) to a callback function
+    param: callback_function: function to invoke during scene transition events
+    """
+    vrFileIOService.newScene.connect(callback_function)
+    vrFileIOService.projectLoad.connect(callback_function)
+
+
+def get_active_camera_name() -> str:
+    """
+    Returns the name of the active camera
+    return: name of the active camera
+    """
+    return vrCameraService.getActiveCamera().getName()
+
+
+def get_animation_clips_list() -> List[str]:
+    """
+    Returns a sorted list of the names of animation clips in the scene
+    return: sorted list of the names of animation clips
+    """
+    return [""] + sorted(getAnimClips())
+
+
+def get_frame_range_string() -> str:
+    """
+    Returns a formatted string representing the current frame range configuration.
+    Examples include:
+        "1" (single frame),
+        "1-100" (100 consecutive frames),
+        "1-100x2" (frames 1,3,5,....99) - specific subset of frames within a sequence
+    return: formatted frame range string
+    """
+    start_frame = getRenderStartFrame()
+    end_frame = getRenderStopFrame()
+    frame_step = getRenderFrameStep()
+    frame_string = str(start_frame)
+    if start_frame != end_frame:
+        frame_string = f"{frame_string}-{str(end_frame)}"
+        if frame_step > 1:
+            frame_string = f"{frame_string}x{str(frame_step)}"
+    return frame_string
+
+
+def get_frame_current() -> int:
+    """
+    return: the current frame number
+    """
+    return getCurrentFrame()
+
+
+def get_frame_start() -> int:
+    """
+    return: the current starting frame number
+    """
+    return getRenderStartFrame()
+
+
+def get_frame_stop() -> int:
+    """
+    return: the current stopping frame number
+    """
+    return getRenderStopFrame()
+
+
+def get_frame_step() -> int:
+    """
+    return: the current frame step value
+    """
+    return getRenderFrameStep()
+
+
+def get_main_window() -> QMainWindow:
+    """
+    return: VRED main window
+    """
+    return vrMainWindow
+
+
+def get_major_version() -> int:
+    """
+    return: VRED version year
+    """
+    return getVredVersionYear()
+
+
+def get_populated_animation_clip_ranges() -> Dict[str, List[float]]:
+    """
+    return: a dictionary containing animation clip names as keys and their corresponding clip ranges as values
+    in the format [start_frame, end_frame].
+    """
+    animation_clip_ranges_map = {"": [0.0, 0.0]}
+    render_fps = get_scene_fps()
+    # Are there referenced animation clips? Or a raw animation clip? (AnimWizClip or AnimBlock types.)
+    #
+    for anim_clip in getAnimClipNodes():
+        clip_name = anim_clip.getName()
+        # Extract the AnimClip's volume attribute's min x to max x (this encodes the start and end range)
+        #
+        start_range = anim_clip.getBoundingBox()[0]
+        end_range = anim_clip.getBoundingBox()[3]
+
+        # Calculate the animation clip ranges
+        #
+        animation_clip_ranges_map[clip_name] = [0.0, 0.0]
+        if is_numerically_defined(str(start_range)) and is_numerically_defined(str(end_range)):
+            duration = end_range - start_range
+            clip_min = start_range * render_fps
+            clip_max = clip_min + (duration * render_fps)
+            animation_clip_ranges_map[clip_name] = [clip_min, clip_max]
+    return animation_clip_ranges_map
+
+
+def get_render_window_size() -> List[int]:
+    """
+    return: width and height of the render window
+    """
+    return [getRenderWindowWidth(0), getRenderWindowHeight(0)]
+
+
+def get_scene_full_path() -> str:
+    """
+    return: full path of the current scene file
+    """
+    return os.path.normpath(vrFileIOService.getFileName())
+
+
+def get_scene_fps() -> float:
+    """
+    Get scene-file specific FPS count value.
+    Note: This value is not directly exposed in the API; UI inspection is applied as a workaround.
+    return: FPS count (assumes DEFAULT_SCENE_FILE_FPS_COUNT if FPS can't be determined).
+    """
+    timeline_action = None
+    timeline_was_visible = False
+
+    try:
+        # Find the timeline object
+        timeline_action = next(
+            (
+                obj
+                for obj in vrMainWindow.findChildren(QAction)
+                if obj.text() == Constants.TIMELINE_ACTION_NAME
+            ),
+            None,
+        )
+        if not timeline_action:
+            raise LookupError(Constants.ERROR_TIMELINE_ACTION_NOT_FOUND)
+
+        # Maintain timeline visibility state
+        timeline_was_visible = timeline_action.isChecked()
+        if not timeline_was_visible:
+            timeline_action.activate(QAction.Trigger)
+
+        # Find toolbar within timeline
+        timeline_toolbar = next(
+            (
+                obj
+                for obj in vrMainWindow.findChildren(QToolBar)
+                if obj.objectName() == Constants.TIMELINE_TOOLBAR_NAME
+            ),
+            None,
+        )
+        if not timeline_toolbar:
+            raise LookupError(Constants.ERROR_TIMELINE_TOOLBAR_NOT_FOUND)
+
+        # Find and click preferences button toolbar
+        prefs_button = next(
+            (
+                obj
+                for obj in timeline_toolbar.findChildren(QToolButton)
+                if obj.objectName() == Constants.TIMELINE_ANIMATION_PREFS_BUTTON_NAME
+            ),
+            None,
+        )
+        if not prefs_button:
+            raise LookupError(Constants.ERROR_PREFERENCES_BUTTON_NOT_FOUND)
+
+        prefs_button.click()
+
+        # In the animation settings dialog, get the FPS value from settings dialog
+        animation_settings_widget = vrMainWindow.findChild(
+            QDialog, Constants.ANIMATION_SETTINGS_DIALOG_NAME
+        )
+        if not animation_settings_widget:
+            raise LookupError(Constants.ERROR_ANIMATION_SETTINGS_DIALOG_NOT_FOUND)
+
+        animation_settings_widget.hide()
+
+        speed_widget = animation_settings_widget.findChild(
+            QObject, Constants.CUSTOM_SPEED_FIELD_NAME
+        )
+        if not speed_widget:
+            raise LookupError(Constants.ERROR_SPEED_SETTINGS_WIDGET_NOT_FOUND)
+        return float(speed_widget.text().split()[0])
+
+    except (LookupError, IndexError, ValueError):
+        return Constants.DEFAULT_SCENE_FILE_FPS_COUNT
+
+    finally:
+        # Always restore timeline visibility to its original state
+        if timeline_action and not timeline_was_visible:
+            timeline_action.activate(QAction.Trigger)
+
+
+def get_render_animation() -> bool:
+    """
+    Get the render animation state.
+    return: True if render animation is enabled; False otherwise.
+    """
+    return getRenderAnimation()
+
+
+def get_render_filename() -> str:
+    """
+    return: filename of the image sequence to render
+    """
+    return getRenderFilename()
+
+
+def get_views_list() -> List[str]:
+    """
+    Retrieves a sorted list of unique view names that are either cameras or viewpoints, but not both.
+    Note: assumes there aren't identical camera names for now; could rely on an index or getPath()
+    return: sorted list of view names that are either cameras or viewpoints, but not both.
+    """
+    camera_name_list = [camera.getName() for camera in vrCameraService.getCameras()]
+    viewpoint_name_list = [vp.getName() for vp in vrCameraService.getAllViewpoints()]
+    return sorted(set(camera_name_list).symmetric_difference(set(viewpoint_name_list)))
+
+
+def is_scene_file_modified() -> bool:
+    """
+    Check if the current scene file has been modified.
+    Examines the main window title to determine if the scene has unsaved changes (denoted with asterisk (*)).
+    return: True if the scene has been modified; False otherwise.
+    """
+    return bool(re.findall(r"\*", get_main_window().windowTitle()))
+
+
+def save_scene_file(filename: str) -> None:
+    """
+    Save the current scene to a file.
+    param: filename: the path to the file to save the scene
+    """
+    if not filename:
+        return
+    vrFileIOService.saveFile(filename)
+
+
+def get_frame_range_components(frame_string: str) -> Tuple[int, int, int]:
+    """
+    Extracts the frame range components from a given frame string.
+    The current supported frame string format is expected to be one of the following:
+    - "a-bxn" where a is start frame, b is end frame, n is the frame step
+    - "a-b" where a is start frame, b is end frame (frame step defaults to 1)
+    - "a" where a is a single frame (start frame==end frame, frame step defaults to 1)
+    Note: negative frame numbers are supported in all positions.
+    param: frame_string: the frame string to parse
+    raise: ValueError: when the frame string format is invalid
+    return: the deduced start frame, end frame, frame step
+    """
+    # Case: single frame
+    if Constants.FRAME_START_STOP_DELIMITER not in frame_string:
+        try:
+            frame = int(frame_string)
+            return frame, frame, 1
+        except ValueError:
+            raise ValueError(f"{Constants.ERROR_FRAME_RANGE_FORMAT}: {frame_string}")
+
+    # Case: frame range with optional step
+    match = re.match(Constants.FRAME_RANGE_REGEX, frame_string)
+
+    if not match:
+        raise ValueError(f"{Constants.ERROR_FRAME_RANGE_FORMAT}: {frame_string}")
+
+    start_frame, end_frame = int(match.group(1)), int(match.group(2))
+
+    # If step is specified, use it; otherwise default to 1
+    step = int(match.group(3)) if match.group(3) else 1
+
+    return start_frame, end_frame, step


### PR DESCRIPTION
- decouples VRED API, providing wrapped methods
- decouples Qt UI control definition, providing wrapped methods and classes
- decouples YAML processing, value comprehension, typing and numerical checks, performance testing constructs
- adds value clamping capability for restricting user-entered values
- adds support for determining frame range components from legacy frame range string format, including support for negative ranges (via regex)
- adds support for __name__ attribute representation applied to keys in a dict (includes primitives)

### What was the problem/requirement? (What/Why)

Reducing the amount of code in individual files. Reducing import dependencies to make code more generic.

### What was the solution? (How)

Decoupling/refactoring code into separate files based on VRED API, Qt, general helper function use.

### What is the impact of this change?

None.

### How was this change tested?

Similar behavior in-app submitter. Individual functions could also be exercised in more detailed tests.

### Was this change documented?

No. No particular user documentation for these changes, but will be relevant for test plans.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
