### PR TITLE
chore(ci): update python versions

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12']
     uses: aws-deadline/.github/.github/workflows/reusable_python_build.yml@mainline
     with:
       os: ${{ matrix.os }}

--- a/hatch.toml
+++ b/hatch.toml
@@ -21,7 +21,7 @@ lint = [
 ]
 
 [[envs.all.matrix]]
-python = ["3.9", "3.10", "3.11"]
+python = ["3.11", "3.12"]
 
 [envs.release]
 detached = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "deadline-cloud-for-vred"
 dynamic = ["version"]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 description = "AWS Deadline Cloud for VRED"
 
 dependencies = [
@@ -52,7 +52,7 @@ packages = [
 ]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.11"
 check_untyped_defs = true
 show_error_codes = true
 pretty = true


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The GitHub test action should test against the same Python version (or major version) that VRED uses.
- VRED 2025: 3.11.9 (tags/v3.11.9:de54cf5, Apr  2 2024, 10:12:12) [MSC v.1938 64 bit (AMD64)]
- VRED 2026: 3.11.11 (main, Dec 17 2024, 17:33:24) [MSC v.1929 64 bit (AMD64)]

There is a github workflow failure on `from enum import StrEnum` in PR #9,  since `StrEnum` was introduced in Python 3.11 but the mypy version we specify in `pyproject.toml` is 3.9.

### What was the solution? (How)
Update `pyproject.toml`, `hatch.toml`, etc. so that we run the python build and type checks against the Python versions that VRED uses

### What is the impact of this change?
Make the github workflow pass

### How was this change tested?
Pulled the code changes (branch) in PR #9 on my local, and ran `hatch run lint` to reproduce the error:
```
src/deadline/vred_submitter/VRED_RenderScript_DeadlineCloud.py:58: error: Module "enum" has no attribute "StrEnum" 
[attr-defined]
    from enum import IntEnum, StrEnum
    ^
```
Ran the lint again with the changes in this PR, and confirmed that the error dissappeared. 

### Was this change documented?
N/A

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
