### PR TITLE
fix: visual UX improvements and support to respect existing stock render options values

### DIFF
--- a/src/deadline/vred_submitter/constants.py
+++ b/src/deadline/vred_submitter/constants.py
@@ -3,7 +3,7 @@
 """Provides a Constants class that focuses on the backend submitter component"""
 
 from pathlib import Path
-from typing import List, Final
+from typing import Final
 
 
 class ConstantsMeta(type):
@@ -24,8 +24,6 @@ class Constants(metaclass=ConstantsMeta):
     ANIMATION_SETTINGS_DIALOG_NAME: Final[str] = "Animation Settings"
     ASSET_REFERENCES_FILENAME: Final[str] = "asset_references.yaml"
     BASE_TEN: Final[int] = 10
-    COMBO_BOX_MIN_WIDTH: Final[int] = 100
-    COMBO_BOX_PADDING: Final[int] = 60
     CONDA_CHANNELS_FIELD: Final[str] = "CondaChannels"
     CONDA_CHANNELS_OVERRIDE_ENV_VAR: Final[str] = "CONDA_CHANNELS"
     CONDA_PACKAGES_FIELD: Final[str] = "CondaPackages"
@@ -41,7 +39,6 @@ class Constants(metaclass=ConstantsMeta):
     DEFAULT_JOB_TEMPLATE_FILENAME: Final[str] = "default_vred_job_template.yaml"
     DEFAULT_SCENE_FILE_FPS_COUNT: Final[float] = 24.0
     DESCRIPTION_FIELD: Final[str] = "description"
-    ELLIPSIS_LABEL: Final[str] = "..."
     ENVIRONMENT_FIELD: Final[str] = "environment"
     ERROR_ANIMATION_SETTINGS_DIALOG_NOT_FOUND: Final[str] = "Animation settings dialog not found"
     ERROR_FILE_PERMISSIONS_ISSUE: Final[str] = "Permission denied accessing file"
@@ -70,15 +67,12 @@ class Constants(metaclass=ConstantsMeta):
     ERROR_YAML_INVALID_FORMAT: Final[str] = "Invalid YAML format in"
     ERROR_YAML_OBJECT_NOT_FOUND: Final[str] = "YAML file must contain a dictionary/object, got"
     ERROR_YAML_NOT_FOUND: Final[str] = "YAML file not found"
-    FILENAME_REGEX: Final[str] = r"^[a-zA-Z0-9_\-\.]+$"
+    FILENAME_UNICODE_REGEX: Final[str] = r"^[\w\-\.]+$"
     FRAME_RANGE_FORMAT_REGEX: Final[str] = r"^(-?\d+)-(-?\d+)(?:x(\d+))?$"
     FRAME_START_STOP_DELIMITER: Final[str] = "-"
     HOST_REQUIREMENTS_FIELD: Final[str] = "hostRequirements"
     JOB_BUNDLE_SCRIPTS_FOLDER_PATH: Final[str] = str(Path(DEADLINE_HOME) / "scripts")
     JOB_ENVIRONMENTS_FIELD: Final[str] = "jobEnvironments"
-    MESSAGE_BOX_MIN_WIDTH: Final[int] = 300
-    MESSAGE_BOX_SPACER_PREFERRED_WIDTH: Final[int] = 400
-    MESSAGE_BOX_MAX_WIDTH: Final[int] = 800
     NAME_FIELD: Final[str] = "name"
     NAN: Final[str] = "NaN"
     NEGATIVE_INFINITY: Final[str] = "-inf"
@@ -86,46 +80,21 @@ class Constants(metaclass=ConstantsMeta):
     PARAMETER_VALUES_FIELD: Final[str] = "parameterValues"
     PARAMETER_VALUES_FILENAME: Final[str] = "parameter_values.yaml"
     POSITIVE_INFINITY: Final[str] = "inf"
-    PUSH_BUTTON_MAXIMUM_WIDTH: Final[int] = 100
-    PUSH_BUTTON_MAXIMUM_HEIGHT: Final[int] = 40
-    PUSH_BUTTON_PADDING_PIXELS: Final[int] = 20
-    PUSH_BUTTON_WIDTH_FACTOR: Final[int] = 4
-    QT_GROUP_BOX_STYLESHEET: Final[
-        str
-    ] = """
-            QGroupBox {
-                border: 4px solid #999999;
-                border-radius: 10px;
-                margin-top: 5ex;
-                font-weight: bold;
-                color: #ffffff;
-            }
-            QGroupBox::title {
-                subcontrol-origin: margin;
-                subcontrol-position: top left;
-                padding: 0 10px;
-                background-color: #444444;
-            }
-    """
     READ_FLAG: Final[str] = "r"
     SCENE_FILE_NOT_SAVED_TITLE: Final[str] = "Warning: scene file not saved"
     SCENE_FILE_NOT_SAVED_BODY: Final[str] = (
         "The scene file has unsaved local changes that will not be included in the job "
         "submission.\n\nDo you want to save the scene file before submitting?"
     )
-    SELECT_DIRECTORY_PROMPT: Final[str] = "Select Directory"
-    SELECT_FILE_PROMPT: Final[str] = "Select File"
     SUBMIT_TO_DEADLINE_CLOUD_ACTION_NAME: Final[str] = "Submit To Deadline Cloud"
     STEPS_FIELD: Final[str] = "steps"
-    SUBMITTER_DIALOG_WINDOW_DIMENSIONS: Final[List[int]] = [1500, 1200]
     TEMPLATE_FILENAME: Final[str] = "template.yaml"
-    TILE_ASSEMBLY_STEP_NAME: Final[str] = "TileAssembly"
+    TILE_ASSEMBLY_STEP_NAME: Final[str] = "Tile Assembly"
     TIMELINE_ACTION_NAME: Final[str] = "Timeline"
     TIMELINE_ANIMATION_PREFS_BUTTON_NAME: Final[str] = "_prefs"
     TIMELINE_TOOLBAR_NAME: Final[str] = "Timeline_Toolbar"
     UTF8_FLAG: Final[str] = "utf-8"
     VALUE_FIELD: Final[str] = "value"
-    VERY_LONG_TEXT_ENTRY_WIDTH: Final[int] = 700
     VRED_CORE_CONDA_PACKAGE_PREFIX: Final[str] = "vredcore"
     VRED_PRO_CONDA_PACKAGE_PREFIX: Final[str] = "vred"
     VRED_RENDER_SCRIPT_FILENAME: Final[str] = "VRED_RenderScript_DeadlineCloud.py"

--- a/src/deadline/vred_submitter/data_classes.py
+++ b/src/deadline/vred_submitter/data_classes.py
@@ -18,19 +18,20 @@ class RenderSubmitterUISettings:
     VRED-specific render settings that the submitter UI will reference.
     Note: these case-sensitive settings need to be synchronized with exact field names in template.yaml, UI.
     Note: these settings can't be dynamically loaded in-place using the existing dataclass/field mechanism.
+    Note: values set to False might not be exposed in the submitter UI, but are exposed in the stock UI and backend
     """
 
-    submitter_name: str = field(default="VRED")
-    name: str = field(default="")
-    description: str = field(default="")
-
-    # File references
+    # Internal settings
     #
+    description: str = field(default="")
     input_filenames: list[str] = field(default_factory=list)
     input_directories: list[str] = field(default_factory=list)
+    JobScriptDir: str = field(default=os.path.normpath(os.path.join(Path(__file__).parent)))
+    name: str = field(default="")
     output_directories: list[str] = field(default_factory=list)
+    submitter_name: str = field(default="VRED")
 
-    # Render settings - note settings that are listed as False aren't currently implemented
+    # Render settings - some settings that have a False value aren't currently exposed in the UI
     #
     AnimationClip: str = field(default="")
     AnimationType: str = field(default="Clip")
@@ -60,4 +61,3 @@ class RenderSubmitterUISettings:
     StartFrame: int = field(default=0)
     TonemapHDR: bool = field(default=False)
     View: str = field(default="")
-    JobScriptDir: str = field(default=os.path.normpath(os.path.join(Path(__file__).parent)))

--- a/src/deadline/vred_submitter/default_vred_job_template.yaml
+++ b/src/deadline/vred_submitter/default_vred_job_template.yaml
@@ -398,7 +398,7 @@ parameterDefinitions:
       Output directories.
 
 steps:
-  - name: VREDLaunch
+  - name: VRED Render
     parameterSpace:
       taskParameterDefinitions:
         - name: StartFrameFromCurrentChunk
@@ -482,10 +482,13 @@ steps:
             #   (Windows): C:/Program Files/Autodesk/VREDPro-{version}/bin/WIN64/VREDCore.exe"
             # Note: if both of these environment variables are assigned, then "VREDCORE" will be take precedence.
             #
-
+            import io
             import os
             import platform
             import subprocess
+            import sys
+
+            sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
 
             CODE_PASSING_ENV_VAR = "BOOTSTRAP_CODE"
             DISABLE_PYTHON_SANDBOX_PARAM = "-insecure_python"
@@ -609,10 +612,10 @@ steps:
           anyOf:
             - linux
             - windows
-  - name: TileAssembly
+  - name: Tile Assembly
     description: Combines tiles into individual frames. (step can be excluded as needed.)
     dependencies:
-    - dependsOn: VREDLaunch
+    - dependsOn: VRED Render
     script:
       actions:
         onRun:
@@ -628,50 +631,33 @@ steps:
           import platform
           import subprocess
 
-          CONCATENATE_MODE_PARAM = "-mode concatenate"
           END_FRAME = int("{{Param.EndFrame}}")
+          EVALUATE_SEQUENCE_PARAM = "-evaluate-sequence max"
           IS_WINDOWS = platform.system().lower() == "windows"
           MAGICK_BIN = os.path.normpath(os.environ.get("MAGICK") or "").replace("\\", "/")
-          GEOMETRY_PARAM = "-geometry"
           MIN_WORKERS_IF_UNKNOWN = 4
-          MONTAGE_PARAM = "montage"
           NUM_X_TILES = int("{{Param.NumXTiles}}")
           NUM_Y_TILES = int("{{Param.NumYTiles}}")
           OUTPUT_DIR = os.path.normpath(r"{{Param.OutputDir}}").replace("\\", "/")
           OUTPUT_FILE_PREFIX = "{{Param.OutputFileNamePrefix}}"
           OUTPUT_FORMAT = "{{Param.OutputFormat}}".lower()
-          REGION_RENDERING = "{{Param.RegionRendering}}".lower()=="true"
           START_FRAME = int("{{Param.StartFrame}}")
-          SOURCE_IMAGE_HEIGHT = int("{{Param.ImageHeight}}")
-          SOURCE_IMAGE_WIDTH = int("{{Param.ImageWidth}}")
-          TILE_HEIGHT = SOURCE_IMAGE_HEIGHT // NUM_Y_TILES
-          TILE_PARAM = "-tile"
-          TILE_WIDTH = SOURCE_IMAGE_WIDTH // NUM_X_TILES
-          TRIM_PARAM = "-trim"
 
           def assemble_frame(frame_num: int) -> None:
               """
-              Assembles a given frame from the tiles that comprise it. Filename format: prefix_XxY_AxB.suffix.
+              Assembles a given frame from the tiles that comprise it. Filename format: prefix_YxX_AxB.suffix.
               Assumes that output folder contains tiles in sequential order: left to right from top to bottom.
               :param: frame_num: frame number
               """
               frame_str = f"{frame_num:05d}"
-              # Compute desired tile size (with no spacing). Trim option will remove black borders; the geometry
-              # constraint is used to reach final image resolution, but may still have gaps. Trim option (by itself)
-              # would remove a 1-pixel border from each tile and removes surrounding pixels that match the 
-              # corner pixel color.
-              geometry_value = f"{TILE_WIDTH}x{TILE_HEIGHT}+0+0"
-              input_file_mask = rf"{OUTPUT_DIR}/*{frame_str}.*"
+              # Note: tile value is not [rows]x[columns]; it is [columns]x[rows]
               tile_value = f"{NUM_X_TILES}x{NUM_Y_TILES}"
+              input_file_mask = rf"{OUTPUT_DIR}/*_{tile_value}-{frame_str}.*"
               output_file = rf"{OUTPUT_DIR}/{OUTPUT_FILE_PREFIX}-{frame_str}.{OUTPUT_FORMAT}"
               command_and_arg_list: list[str] = [
                   MAGICK_BIN,
-                  MONTAGE_PARAM,
-                  TRIM_PARAM,
-                  CONCATENATE_MODE_PARAM,
-                  TILE_PARAM,
-                  tile_value,
                   input_file_mask,
+                  EVALUATE_SEQUENCE_PARAM,
                   output_file,
               ]
               try:

--- a/src/deadline/vred_submitter/qt_utils.py
+++ b/src/deadline/vred_submitter/qt_utils.py
@@ -4,7 +4,10 @@
 
 from .qt_components import AutoSizingMessageBox
 
-from PySide6.QtWidgets import QMessageBox
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtWidgets import QMessageBox, QWidget
+
+_WINDOWS_STANDARD_DPI = 96.0
 
 
 def show_qt_ok_message_dialog(title: str, message: str) -> None:
@@ -39,3 +42,21 @@ def get_qt_yes_no_dialog_prompt_result(title: str, message: str, default_to_yes:
     )
     message_box.setDefaultButton(default_button)
     return message_box.exec() == QMessageBox.StandardButton.Yes
+
+
+def center_widget(widget: QWidget) -> None:
+    """
+    Centers the given dialog on the screen.
+    param: widget: the dialog to be centered
+    """
+    screen_geometry = QGuiApplication.primaryScreen().size()
+    x = (screen_geometry.width() - widget.width()) // 2
+    y = (screen_geometry.height() - widget.height()) // 2
+    widget.move(x, y)
+
+
+def get_dpi_scale_factor() -> float:
+    """
+    return: reference DPI scale factor for the primary screen
+    """
+    return QGuiApplication.primaryScreen().logicalDotsPerInch() / _WINDOWS_STANDARD_DPI

--- a/src/deadline/vred_submitter/ui/components/constants.py
+++ b/src/deadline/vred_submitter/ui/components/constants.py
@@ -5,6 +5,25 @@
 from types import MappingProxyType
 from typing import List, Final
 
+# Note: For all Qt Widgets, 1920x1080 @ 100% scale was used to determine baseline X,Y dimension values
+# (at DPIScale.factor=1.0). Changing resolution and scale will maintain the sizing/layout of widgets.
+# Avoid circular dependencies by storing DPI factor here and changing from outside.
+
+
+class DPIScale:
+    factor: float = 1.0
+
+
+_global_dpi_scale = DPIScale()
+
+
+class ClassProperty:
+    def __init__(self, func):
+        self.func = func
+
+    def __get__(self, instance, owner):
+        return self.func(owner)
+
 
 class ConstantsMeta(type):
     """Metaclass to prevent modification of class attributes."""
@@ -25,17 +44,29 @@ class Constants(metaclass=ConstantsMeta):
     ANIMATION_CLIP_LABEL: Final[str] = "Animation Clip"
     ANIMATION_CLIP_LABEL_DESCRIPTION: Final[str] = "The specific animation clip to render."
     ANIMATION_TYPE_LABEL: Final[str] = "Animation Type"
-    ANIMATION_TYPE_LABEL_DESCRIPTION: Final[str] = "The type of animation."
+    ANIMATION_TYPE_LABEL_DESCRIPTION: Final[str] = "The type of animation (Clip or Timeline)."
     ANIMATION_TYPE_OPTIONS: Final[List[str]] = ["Clip", "Timeline"]
     CLIP_LABEL: Final[str] = "Clip"
-    COLUMN_SMALL_SPACING_OFFSET_PIXELS: Final[int] = 40
+
+    @ClassProperty
+    def COLUMN_SMALL_SPACING_OFFSET_PIXELS(cls) -> int:
+        return int(15 * _global_dpi_scale.factor)
+
+    @ClassProperty
+    def COMBO_BOX_MIN_WIDTH(cls) -> int:
+        return int(55 * _global_dpi_scale.factor)
+
+    @ClassProperty
+    def COMBO_BOX_PADDING(cls) -> int:
+        return int(24 * _global_dpi_scale.factor)
+
     CUSTOM_SPEED_FIELD_NAME: Final[str] = "_customSpeed"
     DEFAULT_IMAGE_SIZE_PRESET: Final[str] = "SVGA (800 x 600)"
     DEFAULT_SCENE_FILE_FPS_COUNT: Final[float] = 24.0
     DEFAULT_DPI_RESOLUTION: Final[int] = 72
     DLSS_QUALITY_LABEL: Final[str] = "DLSS Quality"
     DLSS_QUALITY_LABEL_DESCRIPTION: Final[str] = (
-        "Sets the deep learning supersampling (DLSS) quality."
+        "The Deep Learning Super Sampling (DLSS) quality level to apply."
     )
     DLSS_QUALITY_OPTIONS: Final[List[str]] = [
         "Off",
@@ -44,28 +75,39 @@ class Constants(metaclass=ConstantsMeta):
         "Quality",
         "Ultra Performance",
     ]
+    DPI_LABEL: Final[str] = "Resolution (px/inch)"
+    DPI_LABEL_DESCRIPTION: Final[str] = (
+        "The dots-per-inch (DPI) physical scaling factor in (pixels per inch)."
+    )
     ELLIPSIS_LABEL: Final[str] = "..."
     EMPTY_FRAME_RANGE: Final[str] = "0-0"
     ENABLE_REGION_RENDERING_LABEL: Final[str] = "Enable Region Rendering"
     ENABLE_REGION_RENDERING_LABEL_DESCRIPTION: Final[str] = (
-        "If this option is enabled, then the image will be divided into multiple tasks and assembled afterwards."
+        "When enabled, the output rendered image will be divided into multiple tiles (sub-regions) that are first "
+        "rendered as separate tasks for a given frame. These tiles will then be assembled (combined) into one output "
+        "image for a given frame (in a separate task)."
     )
-    FILE_PATH_REGEX_FILTER: Final[str] = r"^[a-zA-Z0-9_\-\. /\\:]+$"
+    FILE_PATH_REGEX_UNICODE_FILTER: Final[str] = r"^[\p{L}\p{N}_\-\. /\\:]+$"
     FRAME_RANGE_BASIC_FORMAT: Final[str] = "%d-%d"
     FRAME_RANGE_LABEL: Final[str] = "Frame Range"
-    FRAME_RANGE_LABEL_DESCRIPTION: Final[str] = "The list of frames to render."
+    FRAME_RANGE_LABEL_DESCRIPTION: Final[str] = (
+        "The list of frames to render (format: 'a', 'a-b', or 'a-bxn', "
+        "where 'a' is the start frame, 'b' is the end frame, and 'n' is "
+        "the frame step)."
+    )
+    FRAME_RANGE_MAX_LENGTH: Final[int] = 31
     FRAME_RANGE_REGEX_FILTER: Final[str] = r"^[0-9x\-]+$"
     FRAMES_PER_TASK_LABEL: Final[str] = "Frames Per Task"
     FRAMES_PER_TASK_LABEL_DESCRIPTION: Final[str] = (
-        "The number of frames that will be rendered at a time for each job's task."
+        "The number of frames that will be rendered at a time for each task within a render job."
     )
     IMAGE_SIZE_LABEL: Final[str] = "Image Size (px w,h)"
-    IMAGE_SIZE_LABEL_DESCRIPTION: Final[str] = "The image size in pixels (width and height)"
+    IMAGE_SIZE_LABEL_DESCRIPTION: Final[str] = "The image size in pixels (width and height)."
     IMAGE_SIZE_PRESET_CUSTOM: Final[str] = "Custom"
     IMAGE_SIZE_PRESET_FROM_RENDER_WINDOW: Final[str] = "From Render Window"
     IMAGE_SIZE_PRESETS_LABEL: Final[str] = "Image Size Presets"
     IMAGE_SIZE_PRESETS_LABEL_DESCRIPTION: Final[str] = (
-        "The available presets for image size and resolution"
+        "The available presets for image size and resolution."
     )
     IMAGE_SIZE_PRESETS_MAP: MappingProxyType[str, list[int]] = MappingProxyType(
         {
@@ -119,27 +161,80 @@ class Constants(metaclass=ConstantsMeta):
         JOB_TYPE_RENDER,
         JOB_TYPE_SEQUENCER,
     ]
-    LONG_TEXT_ENTRY_WIDTH: Final[int] = 500
+
+    @ClassProperty
+    def LONG_TEXT_ENTRY_WIDTH(cls) -> int:
+        return int(200 * _global_dpi_scale.factor)
+
+    @ClassProperty
+    def MESSAGE_BOX_MIN_WIDTH(cls) -> int:
+        return int(100 * _global_dpi_scale.factor)
+
+    @ClassProperty
+    def MESSAGE_BOX_SPACER_PREFERRED_WIDTH(cls) -> int:
+        return int(150 * _global_dpi_scale.factor)
+
+    @ClassProperty
+    def MESSAGE_BOX_MAX_WIDTH(cls) -> int:
+        return int(200 * _global_dpi_scale.factor)
+
     MIN_FRAMES_PER_TASK: Final[int] = 1
     MIN_DPI: Final[int] = 1
     MIN_IMAGE_DIMENSION: Final[int] = 1
+    MIN_PRINT_DIMENSION: Final[float] = 0.04
+    MAX_PRINT_DIMENSION: Final[float] = 25400.0
     MIN_TILES_PER_DIMENSION: Final[int] = 1
     MAX_DPI: Final[int] = 1000
     MAX_FRAMES_PER_TASK: Final[int] = 10000
     MAX_IMAGE_DIMENSION: Final[int] = 10000
     MAX_TILES_PER_DIMENSION: Final[int] = 10000
-    MODERATE_TEXT_ENTRY_WIDTH: Final[int] = 300
+
+    @ClassProperty
+    def MODERATE_TEXT_ENTRY_WIDTH(cls) -> int:
+        return int(145 * _global_dpi_scale.factor)
+
+    @ClassProperty
+    def PUSH_BUTTON_MAXIMUM_WIDTH(cls) -> int:
+        return int(40 * _global_dpi_scale.factor)
+
+    @ClassProperty
+    def PUSH_BUTTON_MAXIMUM_HEIGHT(cls) -> int:
+        return int(40 * _global_dpi_scale.factor)
+
+    @ClassProperty
+    def PUSH_BUTTON_PADDING_PIXELS(cls) -> int:
+        return int(10 * _global_dpi_scale.factor)
+
+    PUSH_BUTTON_WIDTH_FACTOR: Final[int] = 4
     PRINTING_PRECISION_DIGITS_COUNT: Final[int] = 2
     PRINTING_SIZE_LABEL: Final[str] = "Printing Size (cm w,h)"
     PRINTING_SIZE_LABEL_DESCRIPTION: Final[str] = (
-        "The printing size in centimeters (width and height)"
+        "The printing size in centimeters (width and height)."
     )
+    QT_GROUP_BOX_STYLESHEET: Final[
+        str
+    ] = """
+            QGroupBox {
+                border: 4px solid #999999;
+                border-radius: 10px;
+                margin-top: 5ex;
+                font-weight: bold;
+                color: #ffffff;
+            }
+            QGroupBox::title {
+                subcontrol-origin: margin;
+                subcontrol-position: top left;
+                padding: 0 10px;
+                background-color: #444444;
+            }
+    """
     RENDER_ANIMATION_LABEL: Final[str] = "Render Animation"
     RENDER_ANIMATION_LABEL_DESCRIPTION: Final[str] = (
-        "The animation to use, if left blank it will use all enabled clips."
+        "If checked, allows specifying an animation type (which can also include a specific animation clip), "
+        "corresponding frame range and frames per task."
     )
     RENDER_QUALITY_LABEL: Final[str] = "Render Quality"
-    RENDER_QUALITY_LABEL_DESCRIPTION: Final[str] = "The render quality to apply."
+    RENDER_QUALITY_LABEL_DESCRIPTION: Final[str] = "The render quality level to apply."
     RENDER_QUALITY_OPTIONS: Final[List[str]] = [
         "Analytic Low",
         "Analytic High",
@@ -150,36 +245,43 @@ class Constants(metaclass=ConstantsMeta):
     ]
     RENDER_QUALITY_DEFAULT: Final[str] = "Realistic High"
     RENDER_OUTPUT_LABEL: Final[str] = "Render Output"
-    RENDER_OUTPUT_LABEL_DESCRIPTION: Final[str] = "The filename of the image(s) to be rendered."
+    RENDER_OUTPUT_LABEL_DESCRIPTION: Final[str] = (
+        "The path and filename prefixing of the image(s) to be rendered."
+    )
     RENDER_VIEW_LABEL: Final[str] = "Render Viewpoint/Camera"
-    RENDER_VIEW_LABEL_DESCRIPTION: Final[str] = "The viewpoint or camera to render"
-    RESOLUTION_LABEL: Final[str] = "Resolution (px/inch)"
-    RESOLUTION_LABEL_DESCRIPTION: Final[str] = "The resolution (pixels per inch)"
+    RENDER_VIEW_LABEL_DESCRIPTION: Final[str] = "The viewpoint or camera to render."
     SECTION_RENDER_OPTIONS: Final[str] = "Render Options"
     SECTION_SEQUENCER_OPTIONS: Final[str] = "Sequencer Options"
     SECTION_TILING_SETTINGS: Final[str] = "Tiling Settings"
+    SELECT_DIRECTORY_PROMPT: Final[str] = "Select Directory"
+    SELECT_FILE_PROMPT: Final[str] = "Select File"
     SELECTED_IMAGE_LABEL: Final[str] = "Selected Image"
     SEQUENCE_NAME_LABEL: Final[str] = "Sequence Name"
     SEQUENCE_NAME_LABEL_DESCRIPTION: Final[str] = (
-        "The name of the sequence to run, if empty all sequences will be run."
+        "The name of the sequence to run; if empty all sequences will be run."
     )
-    SHORT_TEXT_ENTRY_WIDTH: Final[int] = 200
+
+    @ClassProperty
+    def SHORT_TEXT_ENTRY_WIDTH(cls) -> int:
+        return int(70 * _global_dpi_scale.factor)
+
     SS_QUALITY_LABEL: Final[str] = "SS Quality"
     SS_QUALITY_LABEL_DESCRIPTION: Final[str] = (
-        "Sets the regular (non-DLSS) supersampling quality. DLSS quality takes precedence."
+        "The Super Sampling quality level to apply; note: DLSS quality level takes precedence."
     )
     SS_QUALITY_OPTIONS: Final[List[str]] = ["Off", "Low", "Medium", "High", "Ultra High"]
-    SUBMIT_DEPENDENT_ASSEMBLY_JOB_LABEL: Final[str] = "Submit Dependent Assembly Job"
-    SUBMIT_DEPENDENT_ASSEMBLY_JOB_LABEL_DESCRIPTION: Final[str] = (
-        "If this option is enabled then an assembly job will be submitted."
-    )
+
+    @ClassProperty
+    def SUBMITTER_DIALOG_WINDOW_DIMENSIONS(cls) -> List[int]:
+        return [int(600 * _global_dpi_scale.factor), int(500 * _global_dpi_scale.factor)]
+
     TILES_IN_X_LABEL: Final[str] = "Tiles In X"
     TILES_IN_X_LABEL_DESCRIPTION: Final[str] = (
-        "The number of tiles to horizontally divide the region into."
+        "The number of tiles to horizontally divide the specified image size."
     )
     TILES_IN_Y_LABEL: Final[str] = "Tiles In Y"
     TILES_IN_Y_LABEL_DESCRIPTION: Final[str] = (
-        "The number of tiles to vertically divide the region into."
+        "The number of tiles to vertically divide the specified  image size."
     )
     TIMELINE_ACTION_NAME: Final[str] = "Timeline"
     TIMELINE_ANIMATION_PREFS_BUTTON_NAME: Final[str] = "_prefs"
@@ -190,10 +292,17 @@ class Constants(metaclass=ConstantsMeta):
         "selected animation clip."
     )
     USE_GPU_RAY_TRACING_LABEL: Final[str] = "Use GPU Ray Tracing"
-    USE_GPU_RAY_TRACING_LABEL_DESCRIPTION: Final[str] = "Use GPU Ray Tracing."
+    USE_GPU_RAY_TRACING_LABEL_DESCRIPTION: Final[str] = "Apply GPU-based Ray Tracing."
     UTF8_FLAG = "utf-8"
-    VERY_LONG_TEXT_ENTRY_WIDTH: Final[int] = 700
-    VERY_SHORT_TEXT_ENTRY_WIDTH: Final[int] = 150
+
+    @ClassProperty
+    def VERY_LONG_TEXT_ENTRY_WIDTH(cls) -> int:
+        return int(280 * _global_dpi_scale.factor)
+
+    @ClassProperty
+    def VERY_SHORT_TEXT_ENTRY_WIDTH(cls) -> int:
+        return int(50 * _global_dpi_scale.factor)
+
     VRED_ALL_FILES_FILTER: Final[str] = "All Files (*.*)"
     VRED_IMAGE_EXPORT_FILTER: Final[str] = (
         "*.png (*.png);;*.bmp (*.bmp);;*.dds (*.dds);;*.dib (*.dib);;"

--- a/src/deadline/vred_submitter/ui/components/scene_settings_widget.py
+++ b/src/deadline/vred_submitter/ui/components/scene_settings_widget.py
@@ -147,7 +147,6 @@ class SceneSettingsWidget(QWidget):
         self._add_image_size_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
         self._add_printing_size_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
         self._add_resolution_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
-        self._add_render_animation_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
         self.render_quality_widget = self._add_label_and_widget(
             grid_layout,
             row_counter,
@@ -172,6 +171,7 @@ class SceneSettingsWidget(QWidget):
             Constants.SS_QUALITY_LABEL_DESCRIPTION,
             AutoSizedComboBox,
         )
+        self._add_render_animation_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
         self._add_animation_type_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
         self._add_animation_clip_controls(grid_layout, row_counter, self.DEFAULT_WIDGET_ALIGNMENT)
         self.use_clip_range_widget = QCheckBox(Constants.USE_CLIP_RANGE_LABEL)
@@ -255,7 +255,7 @@ class SceneSettingsWidget(QWidget):
         render_output_layout.addWidget(self.render_output_widget)
         render_output_layout.addWidget(self.render_output_button)
         grid_layout.addLayout(render_output_layout, next(row_counter), 1, alignment)
-        regex = QRegularExpression(Constants.FILE_PATH_REGEX_FILTER)
+        regex = QRegularExpression(Constants.FILE_PATH_REGEX_UNICODE_FILTER)
         validator = QRegularExpressionValidator(regex)
         self.render_output_widget.setValidator(validator)
 
@@ -332,10 +332,11 @@ class SceneSettingsWidget(QWidget):
         printing_size_layout.addWidget(self.printing_size_y_widget)
         grid_layout.addLayout(printing_size_layout, next(row_counter), 1, alignment)
         printing_size_validator = QDoubleValidator(
-            Constants.MIN_IMAGE_DIMENSION,
-            Constants.MAX_IMAGE_DIMENSION,
+            Constants.MIN_PRINT_DIMENSION,
+            Constants.MAX_PRINT_DIMENSION,
             Constants.PRINTING_PRECISION_DIGITS_COUNT,
         )
+        printing_size_validator.setNotation(QDoubleValidator.Notation.StandardNotation)
         self.printing_size_x_widget.setValidator(printing_size_validator)
         self.printing_size_y_widget.setValidator(printing_size_validator)
 
@@ -351,8 +352,8 @@ class SceneSettingsWidget(QWidget):
         param: row_counter: tracks row number that UI elements added
         param: alignment: alignment for the label and widget
         """
-        self.resolution_label = QLabel(Constants.RESOLUTION_LABEL)
-        self.resolution_label.setToolTip(Constants.RESOLUTION_LABEL_DESCRIPTION)
+        self.resolution_label = QLabel(Constants.DPI_LABEL)
+        self.resolution_label.setToolTip(Constants.DPI_LABEL_DESCRIPTION)
         grid_layout.addWidget(self.resolution_label, iterator_value(row_counter), 0, alignment)
         self.resolution_widget = QLineEdit("")
         self.resolution_widget.setFixedWidth(Constants.SHORT_TEXT_ENTRY_WIDTH)
@@ -434,6 +435,7 @@ class SceneSettingsWidget(QWidget):
         regex = QRegularExpression(Constants.FRAME_RANGE_REGEX_FILTER)
         validator = QRegularExpressionValidator(regex)
         self.frame_range_widget.setValidator(validator)
+        self.frame_range_widget.setMaxLength(Constants.FRAME_RANGE_MAX_LENGTH)
 
     def _add_frames_per_task_controls(
         self,

--- a/src/deadline/vred_submitter/utils.py
+++ b/src/deadline/vred_submitter/utils.py
@@ -12,7 +12,7 @@ from .constants import Constants
 
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, TypeVar, Union
+from typing import Any, Callable, Dict, Iterator, List, Tuple, TypeVar, Union
 from yaml.parser import ParserError
 from yaml.scanner import ScannerError
 
@@ -227,4 +227,18 @@ def is_valid_filename(filename: str) -> bool:
     """
     return: True if filename consists of characters comprising a valid filename; False otherwise
     """
-    return bool(re.match(Constants.FILENAME_REGEX, filename))
+    return bool(re.match(Constants.FILENAME_UNICODE_REGEX, filename, re.UNICODE))
+
+
+def get_file_name_path_components(filename_with_path: str) -> Tuple[str, str, str]:
+    """
+    Extracts the directory, filename prefix, and extension from filename_with_path.
+    param: filename_with_path: path to examine
+    return: the directory, filename prefix, and extension
+    """
+    if not filename_with_path:
+        return "", "", ""
+    directory = get_normalized_path(os.path.dirname(filename_with_path))
+    filename_prefix = os.path.splitext(os.path.basename(filename_with_path))[0]
+    extension = os.path.splitext(filename_with_path)[1][1:]
+    return directory, filename_prefix, extension

--- a/src/deadline/vred_submitter/vred_utils.py
+++ b/src/deadline/vred_submitter/vred_utils.py
@@ -17,15 +17,75 @@ from PySide6.QtWidgets import QDialog, QMainWindow, QToolBar, QToolButton
 from builtins import vrCameraService, vrFileIOService, vrMainWindow, vrReferenceService  # type: ignore[attr-defined]
 from vrAnimWidgets import getAnimClips, getAnimClipNodes, getCurrentFrame
 from vrController import getVredVersionYear
-from vrOSGWidget import getRenderWindowHeight, getRenderWindowWidth
+from vrOSGWidget import (
+    getDLSSQuality,
+    getRenderWindowHeight,
+    getRenderWindowWidth,
+    getSuperSamplingQuality,
+    VR_QUALITY_ANALYTIC_HIGH,
+    VR_QUALITY_ANALYTIC_LOW,
+    VR_QUALITY_NPR,
+    VR_QUALITY_RAYTRACING,
+    VR_QUALITY_REALISTIC_HIGH,
+    VR_QUALITY_REALISTIC_LOW,
+    VR_SS_QUALITY_HIGH,
+    VR_SS_QUALITY_LOW,
+    VR_SS_QUALITY_MEDIUM,
+    VR_SS_QUALITY_OFF,
+    VR_SS_QUALITY_ULTRA_HIGH,
+    VR_DLSS_BALANCED,
+    VR_DLSS_PERFORMANCE,
+    VR_DLSS_OFF,
+    VR_DLSS_QUALITY,
+    VR_DLSS_ULTRA_PERFORMANCE,
+)
 from vrRenderSettings import (
+    getRaytracingMode,
+    getRenderAlpha,
     getRenderAnimation,
+    getRenderAnimationClip,
+    getRenderAnimationType,
     getRenderFilename,
     getRenderFrameStep,
+    getRenderPixelHeight,
+    getRenderPixelPerInch,
+    getRenderPixelWidth,
+    getRenderPremultiply,
     getRenderStartFrame,
     getRenderStopFrame,
+    getRenderTonemapHDR,
+    getRenderUseClipRange,
+    getRenderView,
+    getUseRenderRegion,
 )
 from vrSequencer import getSequenceList
+
+ANIMATION_TYPE_DICT: Dict[int, str] = {0: "Clip", 1: "Timeline"}
+
+DLSS_QUALITY_DICT: Dict[int, str] = {
+    VR_DLSS_OFF: "Off",
+    VR_DLSS_PERFORMANCE: "Performance",
+    VR_DLSS_BALANCED: "Balanced",
+    VR_DLSS_QUALITY: "Quality",
+    VR_DLSS_ULTRA_PERFORMANCE: "Ultra Performance",
+}
+
+RENDER_QUALITY_DICT: Dict[int, str] = {
+    VR_QUALITY_ANALYTIC_LOW: "Analytic Low",
+    VR_QUALITY_ANALYTIC_HIGH: "Analytic High",
+    VR_QUALITY_REALISTIC_LOW: "Realistic Low",
+    VR_QUALITY_REALISTIC_HIGH: "Realistic High",
+    VR_QUALITY_RAYTRACING: "Raytracing",
+    VR_QUALITY_NPR: "NPR",
+}
+
+SS_QUALITY_DICT: Dict[int, str] = {
+    VR_SS_QUALITY_OFF: "Off",
+    VR_SS_QUALITY_LOW: "Low",
+    VR_SS_QUALITY_MEDIUM: "Medium",
+    VR_SS_QUALITY_HIGH: "High",
+    VR_SS_QUALITY_ULTRA_HIGH: "Ultra High",
+}
 
 
 def assign_scene_transition_event(callback_function) -> None:
@@ -51,6 +111,38 @@ def get_animation_clips_list() -> List[str]:
     return: sorted list of the names of animation clips
     """
     return [""] + sorted(getAnimClips())
+
+
+def get_dlss_quality() -> str:
+    """
+    Returns the DLSS quality value
+    return: DLSS quality value
+    """
+    return DLSS_QUALITY_DICT.get(getDLSSQuality(), "")
+
+
+def get_supersampling_quality() -> str:
+    """
+    Returns the supersampling quality value
+    return: supersampling quality value
+    """
+    return SS_QUALITY_DICT.get(getSuperSamplingQuality(), "")
+
+
+def get_render_pixel_height() -> int:
+    """
+    Returns the pixel height for rendering
+    return: pixel height value
+    """
+    return getRenderPixelHeight()
+
+
+def get_render_pixel_width() -> int:
+    """
+    Returns the pixel height for rendering
+    return: pixel height value
+    """
+    return getRenderPixelWidth()
 
 
 def get_frame_range_string() -> str:
@@ -164,6 +256,20 @@ def get_all_sequences() -> List[str]:
     return sorted(getSequenceList())
 
 
+def get_animation_clip() -> str:
+    """
+    return: the name of the current animation clip
+    """
+    return getRenderAnimationClip()
+
+
+def get_animation_type() -> str:
+    """
+    return: the type of the current animation
+    """
+    return ANIMATION_TYPE_DICT.get(getRenderAnimationType(), "")
+
+
 def get_render_window_size() -> List[int]:
     """
     return: width and height of the render window
@@ -256,6 +362,13 @@ def get_scene_fps() -> float:
             timeline_action.activate(QAction.Trigger)
 
 
+def get_render_alpha() -> bool:
+    """
+    return: True if an alpha channel should be exported; False otherwise.
+    """
+    return getRenderAlpha()
+
+
 def get_render_animation() -> bool:
     """
     Get the render animation state.
@@ -264,11 +377,62 @@ def get_render_animation() -> bool:
     return getRenderAnimation()
 
 
+def get_render_pixel_per_inch() -> int:
+    """
+    Get the render pixel per inch value.
+    return: pixel per inch value
+    """
+    return int(getRenderPixelPerInch())
+
+
+def get_render_view() -> str:
+    """
+    Get the current render view (camera name).
+    return: name of current render view
+    """
+    return getRenderView()
+
+
 def get_render_filename() -> str:
     """
     return: filename of the image sequence to render
     """
     return get_normalized_path(getRenderFilename())
+
+
+def get_premultiply_alpha() -> bool:
+    """
+    return: True if premultiplied alpha is enabled; False otherwise.
+    """
+    return getRenderPremultiply()
+
+
+def get_tonemap_hdr() -> bool:
+    """
+    return: True if Tonemap HDR is enabled; False otherwise.
+    """
+    return getRenderTonemapHDR()
+
+
+def get_use_clip_range() -> bool:
+    """
+    return: True if clip range is enabled; False otherwise.
+    """
+    return getRenderUseClipRange()
+
+
+def get_use_gpu_ray_tracing() -> bool:
+    """
+    return: True if GPU raytracing is enabled, False otherwise
+    """
+    return getRaytracingMode()
+
+
+def get_use_render_region() -> bool:
+    """
+    return: True if render region is enabled; False otherwise.
+    """
+    return getUseRenderRegion()
 
 
 def get_views_list() -> List[str]:

--- a/vred_submitter_plugin/plug-ins/DeadlineCloudForVRED.py
+++ b/vred_submitter_plugin/plug-ins/DeadlineCloudForVRED.py
@@ -38,7 +38,7 @@ ERROR_MSG_CLIENT_MISSING = (
     "Deadline Cloud Client is fully installed and that its directory is present in the system PATH "
     "environment variable. Typical installation directories are:\n"
     "   C:\\DeadlineCloudSubmitter\\DeadlineClient\n"
-    "   %USERPROFILE\\DeadlineCloudSubmitter\\DeadlineClient\n"
+    "   %USERPROFILE%\\DeadlineCloudSubmitter\\DeadlineClient\n"
 )
 
 ERROR_MSG_LOAD_CLIENT = "Encountered an error while loading the Deadline Cloud Client"
@@ -48,8 +48,8 @@ ERROR_MSG_SCRIPT_NOT_FOUND = (
     "The vred_submitter.py script could not be found in the Deadline Cloud Client directory for "
     "VRED. Please ensure that Deadline Cloud for VRED has been fully installed on this machine. "
     "Typical directory locations for vred_submitter.py are:\n"
-    "   C:\\DeadlineCloudSubmitter\\DeadlineClient\\Submitters\\VRED\\scripts\n"
-    "   %USERPROFILE\\DeadlineCloudSubmitter\\DeadlineClient\\Submitters\\VRED\\scripts\n"
+    "   C:\\DeadlineCloudSubmitter\\Submitters\\VRED\\scripts\n"
+    "   %USERPROFILE%\\DeadlineCloudSubmitter\\Submitters\\VRED\\scripts\n"
 )
 PATH_FIELD = "PATH"
 SUBMITTER_BASE_FOLDER_NAME = "DeadlineCloudSubmitter"


### PR DESCRIPTION
- preliminary submitter dialog scaling and centering based on primary monitor resolution
- support to enforce combo box length (after auto-sized length known) to be consistent for fixed item lists
- further clarity in tooltip descriptions
- ensures that there's always a value for image and printing width/height, and DPI.
- ensures before-and-after persistence for UI widget states
- populates render setting values (from stock Render Settings) for the first submitter dialog that opens for a given scene file
- populates render setting values (from stock Render Settings) that weren't exposed in the submitter
- rearranges render animation widget to be near the UI controls that it affects (when toggling)
- applies DPI factor to enforce consistent Qt Window/Widget sizing appearance at different resolution and scale combinations
- improves UI layout with consistent sizing of Qt Widgets
- improved l18n/Unicode support for Qt and worker
- improves the tile assembly algorithm - ImageMagick considers tile overlap and assemble tiles to meet original resolution

### What was the problem/requirement? (What/Why)

Different user environments may display UI visually different. Persistent settings aren't being based on initial scene file stock setting defaults.

### What was the solution? (How)

Query screen DPI and scale Qt widgets as appropriate. Query VRED API for setting values and bootstrap into settings used by Deadline Client API.

### What is the impact of this change?

None, though more positive UX.

### How was this change tested?

Manual UX tests at different screen resolutions, comparing values between stock render options screen and the submitter screen.

### Was this change documented?

Not yet.


### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
