### PR TITLE
ci: update pypi publish to tag based release

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -68,7 +68,7 @@ jobs:
   PublishToPyPI:
     # Skip until the repository is public
     if: ${{ false }}
-    needs: Publish
+    needs: [TagRelease, Publish]
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -77,7 +77,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.Publish.outputs.tag }}
+          ref: ${{ needs.TagRelease.outputs.tag }}
           fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
PyPI is using release branch in the release process, it should be using the release tag

### What was the solution? (How)
Update the PyPI publish job to use tagrelease job.

### What is the impact of this change?
Correct version is published to pypi

### How was this change tested?
n/a

### Was this change documented?
n/a

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*