### PR TITLE
chore: Updates documentation to include manual install steps

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -15,19 +15,14 @@ Table of Contents:
 
 To develop the Python code in this repository you will need:
 
-1. Python 3.11 or higher. We recommend [mise](https://github.com/jdx/mise) if you would like to run more than one
-   version of Python on the same system. When running unit tests against all supported Python versions, for instance.
-2. The [hatch](https://github.com/pypa/hatch) package installed (`pip install hatch`) into your Python
-   environment.
+1. Python 3.11 or higher. We recommend [mise](https://github.com/jdx/mise) if you would like to run more than one version of Python on the same system. When running unit tests against all supported Python versions, for instance.
+2. The [hatch](https://github.com/pypa/hatch) package installed (`pip install hatch`) into your Python environment.
 3. A supported version of VRED Pro or VRED Core with valid bring your own licensing (BYOL).
-4. ImageMagick installed for tile assembly testing (download
-   from [imagemagick.org](https://imagemagick.org/script/download.php)).
+4. ImageMagick installed for tile assembly testing (download from [imagemagick.org](https://imagemagick.org/script/download.php)).
 5. A valid AWS Account.
-6. An AWS Deadline Cloud Farm to run jobs on. We recommend following the quickstart in the Deadline Cloud console to
-   create a Queue with the default Queue Environment, and a Service Managed Fleet.
+6. An AWS Deadline Cloud Farm to run jobs on. We recommend following the quickstart in the Deadline Cloud console to create a Queue with the default Queue Environment, and a Service Managed Fleet.
 
-**Important**: VRED requires **bring your own licensing (BYOL)**. Ensure you have valid VRED licenses available for both
-development and production render farm usage.
+**Important**: VRED requires **bring your own licensing (BYOL)**. Ensure you have valid VRED licenses available for both development and production render farm usage.
 
 ## Software Architecture
 
@@ -154,11 +149,9 @@ The VRED submitter plugin follows a modular architecture:
 
 ## Development Processes/Tools
 
-We have configured [hatch](https://github.com/pypa/hatch) commands to support standard development. You can run the
-following from any directory of this repository:
+We have configured [hatch](https://github.com/pypa/hatch) commands to support standard development. You can run the following from any directory of this repository:
 
-* `hatch shell` - Enter a shell environment that will have Python set up to import your development version of this
-  package.
+* `hatch shell` - Enter a shell environment that will have Python set up to import your development version of this package.
 * `hatch build` - To build the installable Python wheel and sdist packages into the `dist/` directory.
 * `hatch run unit:test` - To run the PyTest unit tests found in the `test/unit` directory.
 * `hatch run worker:test` - (Windows only) To run the PyTest worker tests found in the `test/worker` directory.
@@ -166,19 +159,13 @@ following from any directory of this repository:
 * `hatch run all:test` - To run the PyTest unit tests against all available supported versions of Python.
 * `hatch run lint` - To check that the package's formatting adheres to formatting standards.
 * `hatch run fmt` - To automatically reformat all code to adhere to formatting standards.
-* `hatch env prune` - Delete all of your isolated workspace [environments](https://hatch.pypa.io/1.12/environment/) for
-  this package.
+* `hatch env prune` - Delete all of your isolated workspace [environments](https://hatch.pypa.io/1.12/environment/) for this package.
 
-Note: Hatch uses [environments](https://hatch.pypa.io/1.12/environment/) to isolate the Python development workspace for
-this package from your system or virtual environment Python. If your build/test run is not making sense, then sometimes
-pruning (`hatch env prune`) all of these environments for the package can fix the issue.
+Note: Hatch uses [environments](https://hatch.pypa.io/1.12/environment/) to isolate the Python development workspace for this package from your system or virtual environment Python. If your build/test run is not making sense, then sometimes pruning (`hatch env prune`) all of these environments for the package can fix the issue.
 
 ### Submitter Development Workflow
 
-The submitter plug-in generates job bundles to submit to AWS Deadline Cloud. Developing a change to the submitter
-involves iteratively changing the plug-in code, then running the plug-in within VRED to generate or submit a job bundle,
-inspecting the generated job bundle to ensure that it is as you expect, and ultimately running that job to ensure that
-it works as desired.
+The submitter plug-in generates job bundles to submit to AWS Deadline Cloud. Developing a change to the submitter involves iteratively changing the plug-in code, then running the plug-in within VRED to generate or submit a job bundle, inspecting the generated job bundle to ensure that it is as you expect, and ultimately running that job to ensure that it works as desired.
 
 #### Running the Plug-In
 
@@ -195,9 +182,7 @@ To run the plug-in for development:
 
 4. Access the submitter through the "Deadline Cloud" menu in VRED.
 
-You can use the "Export Bundle" option in the submitter to save the job bundle for a submission to your local disk to
-inspect it, or the "Submit" button (after selecting your Deadline Cloud Farm and Queue in the submitter UI) to submit
-the job to your farm to run.
+You can use the "Export Bundle" option in the submitter to save the job bundle for a submission to your local disk to inspect it, or the "Submit" button (after selecting your Deadline Cloud Farm and Queue in the submitter UI) to submit the job to your farm to run.
 
 #### Making Submitter Code Changes
 
@@ -210,15 +195,12 @@ Whenever you modify code for the plug-in, or one of its supporting Python librar
 
 The tests for the plug-in have two forms:
 
-1. Unit tests focused on ensuring that function-level behavior of the implementation behaves as expected.
-   These can always be run locally on your workstation without requiring an AWS account.
+1. Unit tests focused on ensuring that function-level behavior of the implementation behaves as expected. These can always be run locally on your workstation without requiring an AWS account.
 2. Integration tests - In-application tests that verify that job submissions generate expected job bundles.
 
 ##### Unit Tests
 
-Unit tests are all located under the `test/unit` directory of this repository. If you are adding or modifying
-functionality, then you will almost always want to be writing one or more unit tests to demonstrate that your logic
-behaves as expected and that future changes do not accidentally break your change.
+Unit tests are all located under the `test/unit` directory of this repository. If you are adding or modifying functionality, then you will almost always want to be writing one or more unit tests to demonstrate that your logic behaves as expected and that future changes do not accidentally break your change.
 
 To run the unit tests, use hatch:
 
@@ -228,8 +210,7 @@ hatch run unit:test
 
 ##### Worker Tests
 
-Worker tests are located under the `test/worker` directory and test the VRED render script and tile assembly
-functionality.
+Worker tests are located under the `test/worker` directory and test the VRED render script and tile assembly functionality.
 
 To run the worker tests:
 
@@ -239,8 +220,7 @@ hatch run worker:test
 
 ##### Integration Tests
 
-Integration tests are located under the `test/integ` directory. These tests verify that the submitter generates correct
-job bundles and that the VRED render script functions properly.
+Integration tests are located under the `test/integ` directory. These tests verify that the submitter generates correct job bundles and that the VRED render script functions properly.
 
 To run the integration tests:
 
@@ -267,9 +247,50 @@ The integration tests include:
 
 ##### Test Configuration
 
-Integration tests use scene files located in `test/integ/scene_files/` and compare output against expected baselines in
-`test/integ/expected_output/`. Test parameters can be customized through parameter and asset overrides in the test
-configuration.
+Integration tests use scene files located in `test/integ/scene_files/` and compare output against expected baselines in `test/integ/expected_output/`. Test parameters can be customized through parameter and asset overrides in the test configuration.
+
+### Manual Installation
+#### Prerequisites
+
+1. Install the required applications:
+    - VRED Pro 2025/2026 [Autodesk](https://manage.autodesk.com)
+    - [Deadline Cloud Client][deadline-cloud-client]
+    - [Deadline Cloud Monitor](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/open-deadline-cloud-monitor.html)
+1. Open Deadline Cloud Monitor and perform sign-in on an appropriate profile.
+1. [Clone this repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository#cloning-a-repository).
+1. Ensure you have `pip` available in your terminal.
+
+#### Installation Steps
+
+For the instructions that follow, change the directory names as appropriate to correspond to the VRED installation where you would like to install the Submitter. For example, for VRED Core 2026, the 18.X numbering convention was applied to the VREDCore-18.0 portion of the path.
+
+1. Set-up development environment:
+    - `pip install --upgrade -r requirements-development.txt`
+1. Create submitter directory
+    - run `hatch build` in your local git repository
+    - Windows: `xcopy -r src\deadline\vred_submitter\ ~%USERPROFILE%\DeadlineCloudSubmitter\Submitters\VRED\scripts\deadline\vred_submitter /s /e /h`
+1. Install submitter dependencies:
+    - Windows: `pip install --python-version 3.11 --only-binary=:all: "deadline[gui]" -t %USERPROFILE%\DeadlineCloudSubmitter\Submitters\VRED\python\modules`
+1. Set the `DEADLINE_VRED_MODULES` environment variable to point to your VRED module install:
+    - Windows: `setx DEADLINE_VRED_MODULES %USERPROFILE%\DeadlineCloudSubmitter\Submitters\VRED`
+1. Install the Submitter plug-in into VRED's environment:
+    - Copy `vred_submitter_plugin/plug-ins/DeadlineCloudForVRED.py` from this repository to VRED's Python libraries directory:
+        - For VRED Core: `C:\Program Files\Autodesk\VREDCore-18.0\lib\python\Lib\site-packages`
+        - For VRED Pro: `C:\Program Files\Autodesk\VREDPro-18.0\lib\python\Lib\site-packages`
+1. Configure the VRED Submitter plug-in to load on startup.
+    - Start VRED Pro and click on these items: `Edit menu → Preferences → General Settings → Script`
+    - Please ensure that the `Enable Python Sandbox` option is unchecked since AWS Deadline Cloud requires network and file access by default.
+    - In the `Script` section, scroll to the bottom and append:
+      ```python
+      from DeadlineCloudForVRED import DeadlineCloudForVRED
+      DeadlineCloudForVRED()
+      ```
+    - Click the `Save` button
+1. Supply AWS account credentials for the submitter to use when submitting a render job through either of these steps:
+    - [Install and set up the Deadline Cloud Monitor][deadline-cloud-monitor-setup], and then log in to the monitor. (Logging in to the monitor will make AWS credentials available to the submitter, automatically.)
+    - Set up an AWS credentials profile [as you would for the AWS CLI][aws-cli-credentials], and select that profile for the submitter to use.
+    - Or default to your AWS EC2 instance profile credentials if you are running a workstation in the cloud.
+1. Restart VRED to refresh environment variables.
 
 ## Environment Variables
 
@@ -300,8 +321,7 @@ configuration.
 
 ## Submitter UI Configuration
 
-The submitter UI is configured through parameters defined in `default_vred_job_template.yaml` and UI constants in
-`ui/components/constants.py`:
+The submitter UI is configured through parameters defined in `default_vred_job_template.yaml` and UI constants in `ui/components/constants.py`:
 
 ### Render Parameters
 
@@ -321,8 +341,7 @@ The submitter UI is configured through parameters defined in `default_vred_job_t
 
 ### Debug Mode
 
-Enable detailed logging by setting the log level in your test environment or by modifying the logger configuration in
-the VRED submitter code.
+Enable detailed logging by setting the log level in your test environment or by modifying the logger configuration in the VRED submitter code.
 
 ### Parameter Validation
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@
 [![python](https://img.shields.io/pypi/pyversions/deadline-cloud-for-vred.svg?style=flat)](https://pypi.python.org/pypi/deadline-cloud-for-vred)
 [![license](https://img.shields.io/pypi/l/deadline-cloud-for-vred.svg?style=flat)](https://github.com/aws-deadline/deadline-cloud-for-vred/blob/mainline/LICENSE)
 
-AWS Deadline Cloud for VRED is a Python-based package that supports creating and running Autodesk VRED render jobs
-within [AWS Deadline Cloud][deadline-cloud]. It provides a user-friendly VRED submitter plug-in for your Windows-based
-workstation. You can choose from a set of common render options and offload the computation of your rendering
-workloads to [AWS Deadline Cloud][deadline-cloud] to reduce the load on local compute resources to pursue other tasks.
+AWS Deadline Cloud for VRED is a Python-based package that supports creating and running Autodesk VRED render jobs within [AWS Deadline Cloud][deadline-cloud]. It provides a user-friendly VRED submitter plug-in for your Windows-based workstation. You can choose from a set of common render options and offload the computation of your rendering workloads to [AWS Deadline Cloud][deadline-cloud] to reduce the load on local compute resources to pursue other tasks.
 
 [aws-cli-credentials]: https://docs.aws.amazon.com/cli/v1/userguide/cli-chap-authentication.html
 
@@ -36,124 +33,31 @@ workloads to [AWS Deadline Cloud][deadline-cloud] to reduce the load on local co
 The AWS Deadline Cloud for VRED package requires:
 
 1. VRED Pro or VRED Core 2025/2026 and its [requirements][vred-requirements]
-    - Note: at the time of writing, it is strongly recommended to use NVIDIA GPU driver 553.xx  (until future
-      driver
-      levels pass hardware qualifications for VRED.)
+    - Note: at the time of writing, it is strongly recommended to use NVIDIA GPU driver 553.xx  (until future driver levels pass hardware qualifications for VRED.)
 2. Python 3.11 or higher;
 3. Operating System support:
     - Windows 10+ (for the in-app VRED Submitter plugin, Worker, Standalone AWS Deadline Cloud client submitter)
     - Linux (for the Worker, Standalone AWS Deadline Cloud client Submitter)
     - macOS (for the Standalone AWS Deadline Cloud client Submitter)
-4. Optionally: [ImageMagick](https://imagemagick.org/) static binary (to support tile assembly when region rendering
-   with raytracing is applied).
+4. Optionally: [ImageMagick](https://imagemagick.org/) static binary (to support tile assembly when region rendering with raytracing is applied).
 
-**Important**: This integration of AWS Deadline Cloud into VRED requires **bring your own licensing (BYOL)** for VRED.
-You must have valid VRED licenses available for your render farm fleet.
+**Important**: This integration of AWS Deadline Cloud into VRED requires **bring your own licensing (BYOL)** for VRED. You must have valid VRED licenses available for your render farm fleet.
 
-## Versioning
+## Submitter
 
-This package's version follows [Semantic Versioning 2.0](https://semver.org/), but it is still considered to be in its
-initial development, thus backwards incompatible versions are denoted by minor version bumps. To help illustrate how
-versions will increment during this initial development stage, they are described below:
+This VRED integration for AWS Deadline Cloud provides an in-app Submitter plug-in. It must be installed on the Windows workstation that you will use to submit render jobs from within VRED Pro.
 
-1. The MAJOR version is currently 0, indicating initial development.
-2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API.
-3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the
-   public API.
+Before submitting any large, complex, or otherwise compute-heavy VRED render jobs to your farm, we strongly recommend that you construct a simple test scene file that can be rendered quickly. You can then submit renders of that scene to your render farm fleet to ensure that its setup is correctly functioning.
 
-## Getting Started
+### Getting Started
 
-This VRED integration for AWS Deadline Cloud provides an in-app Submitter plug-in. It must be installed on the
-Windows workstation that you will use to submit render jobs from within VRED Pro.
+If you have installed the submitter using the Deadline Cloud submitter installer you can follow the guide to [Setup Deadline Cloud submitters](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html#load-dca-plugin) for the manual steps needed after installation.
 
-Before submitting any large, complex, or otherwise compute-heavy VRED render jobs to your farm, we strongly
-recommend that you construct a simple test scene file that can be rendered quickly. You can then submit renders of that
-scene to your render farm fleet to ensure that its setup is correctly functioning.
+If you are setting up the submitter for a developer workflow or manual installation you can follow the instructions in the [DEVELOPMENT](DEVELOPMENT.md#manual-installation) file.
 
 ### VRED Submitter Plug-in
 
-The VRED Submitter plug-in creates a menu (Deadline Cloud) and menu item (Submit to Deadline Cloud) in VRED's
-menu bar, which can be used to submit render jobs to AWS Deadline Cloud. This menu item launches a Submitter UI to
-create a job submission for AWS Deadline Cloud using the [AWS Deadline Cloud client library][deadline-cloud-client].
-It automatically determines the files required for submission based on the loaded scene file (includes Source/Smart
-references as dependencies.) Additionally, the Submitter provides basic render options (in the Job-specific settings
-tab), and builds an [Open Job Description template][openjd] that defines the render pipeline workflow. From there, the
-Submitter submits the render job to the render farm queue and fleet of your choice.
-
-#### Prerequisites
-
-1. Install the required applications:
-    - VRED Pro 2025/2026 [Autodesk](https://manage.autodesk.com)
-    - [Deadline Cloud Client][deadline-cloud-client]
-    - [Deadline Cloud Monitor](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/open-deadline-cloud-monitor.html)
-
-2. Open Deadline Cloud Monitor and perform sign-in on an appropriate profile (see instructions below).
-
-#### Submitter (Manual Installation Steps)
-
-If you are not using an installer package for installing the Submitter, then you can install it by applying the
-following manual installation steps (below). For the instructions that follow, change the directory names as
-appropriate to correspond to the VRED installation where you would like to install the Submitter. For example, for VRED
-Core 2026, the 18.X numbering convention was applied to the VREDCore-18.0 portion of the path.
-
-1. Fetch the latest AWS Deadline Cloud for VRED code:
-   ```cmd
-   git clone https://github.com/aws-deadline/deadline-cloud-for-vred
-   cd deadline-cloud-for-vred
-   # Note: for updates: git fetch
-   ```
-
-2. Install the Submitter plug-in:
-    - Create submitter installation directories:
-   ```cmd
-   mkdir C:\DeadlineCloudSubmitter\Submitters\VRED\scripts\deadline
-   # or
-   mkdir %USERPROFILE%\DeadlineCloudSubmitter\Submitters\VRED\scripts\deadline
-   ```
-    - Copy `vred_submitter_plugin/plug-ins/DeadlineCloudForVRED.py` to VRED's Python libraries directory:
-        - For VRED Core: `C:\Program Files\Autodesk\VREDCore-18.0\lib\python\Lib\site-packages`
-        - For VRED Pro: `C:\Program Files\Autodesk\VREDPro-18.0\lib\python\Lib\site-packages`
-    - Copy `src/deadline/vred_submitter` to your Deadline Cloud submitter directory:
-      `C:\DeadlineCloudSubmitter\Submitters\VRED\scripts\deadline` or
-      `%USERPROFILE%\DeadlineCloudSubmitter\Submitters\VRED\scripts\deadline`
-
-3. Set environment variables (examples for VRED Pro and VRED Core 2026):
-   ```cmd
-   # For VRED Core
-   setx VREDCORE "C:\Program Files\Autodesk\VREDCore-18.0\bin\WIN64\VREDCore.exe"
-   # or for VRED Pro
-   setx VREDPRO "C:\Program Files\Autodesk\VREDPro-18.0\bin\WIN64\VREDPro.exe"
-   ```
-4. Supply AWS account credentials for the submitter to use when submitting a render job through either of these steps:
-    - [Install and set up the Deadline Cloud Monitor][deadline-cloud-monitor-setup], and then log in to the monitor.
-      (Logging in to the monitor will make AWS credentials available to the submitter, automatically.)
-    - Set up an AWS credentials profile [as you would for the AWS CLI][aws-cli-credentials], and select that profile
-      for the submitter to use.
-    - Or default to your AWS EC2 instance profile credentials if you are running a workstation in the cloud.
-
-5. Configure the VRED Submitter plug-in to load on startup.
-    - Start VRED Pro and click on these items: `Edit menu → Preferences → General Settings → Script`
-    - Please ensure that the `Enable Python Sandbox` option is unchecked.
-    - In the `Script` section, scroll to the bottom and append:
-      ```python
-      from DeadlineCloudForVRED import DeadlineCloudForVRED
-      DeadlineCloudForVRED()
-      ```
-    - Click the `Save` button
-
-6. Logout and login to refresh environment variables.
-
-#### Optional: Submitter Post-Installation Steps
-
-The following steps are NOT required or recommended in regular practice:
-
-- Enable VRED's Python Sandbox (this is NOT recommended, since AWS Deadline Cloud requires network and file access by
-  default):
-    - Start VRED Pro and click on these items: `Edit menu → Preferences → General Settings → Script`
-    - In the `Python Sandbox` section, ensure that `Enable Python Sandbox` is enabled
-    - Copy the contents of `python-sandbox-module-allowlist.txt` from this repository into the `Allowed Modules` text
-      box
-    - Click the `Save` button
+The VRED Submitter plug-in creates a menu (Deadline Cloud) and menu item (Submit to Deadline Cloud) in VRED's menu bar, which can be used to submit render jobs to AWS Deadline Cloud. This menu item launches a Submitter UI to create a job submission for AWS Deadline Cloud using the [AWS Deadline Cloud client library][deadline-cloud-client]. It automatically determines the files required for submission based on the loaded scene file (includes Source/Smart references as dependencies.) Additionally, the Submitter provides basic render options (in the Job-specific settings tab), and builds an [Open Job Description template][openjd] that defines the render pipeline workflow. From there, the Submitter submits the render job to the render farm queue and fleet of your choice.
 
 #### Launching the Submitter
 
@@ -161,42 +65,28 @@ The following steps are NOT required or recommended in regular practice:
 2. Open a VRED scene file.
 3. Open the `Deadline Cloud` menu and click the `Submit to Deadline Cloud` menu item to launch the Submitter.
 
-   **Note**: If you have not already authenticated with Deadline Cloud, then the `Authentication Status` section at the
-   bottom of the Submitter will show `NEEDS_LOGIN`.
+   **Note**: If you have not already authenticated with Deadline Cloud, then the `Authentication Status` section at the bottom of the Submitter will show `NEEDS_LOGIN`.
 
-   a) Click the `Login` button. Then, in the web browser window that appears, authenticate using your IAM user
-   credentials.
+   a) Click the `Login` button. Then, in the web browser window that appears, authenticate using your IAM user credentials.
 
-   b) Click the `Allow` button (your login will then be authenticated and the `Authentication Status` section will show `
-   AUTHENTICATED`).
+   b) Click the `Allow` button (your login will then be authenticated and the `Authentication Status` section will show `AUTHENTICATED`).
 
-4. In the `Submit to AWS Deadline Cloud` dialog, configure appropriate settings (including the render settings that are
-   listed in the `Job-specific settings` tab).
+4. In the `Submit to AWS Deadline Cloud` dialog, configure appropriate settings (including the render settings that are listed in the `Job-specific settings` tab).
 5. Click the `Submit` button to submit your render job to AWS Deadline Cloud.
 
 ### VRED Software Availability in AWS Deadline Cloud Service Managed Fleets
 
-Please ensure that the version of VRED that you want to run is also available on the fleet (worker nodes) when you are
-using AWS Deadline Cloud's [Service Managed Fleets][service-managed-fleets] to run render jobs; these fleet hosts do
-not have any rendering applications pre-installed. The standard way of installing applications is
-described [in the service
-documentation](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/provide-applications.html).
+Please ensure that the version of VRED that you want to run is also available on the fleet (worker nodes) when you are using AWS Deadline Cloud's [Service Managed Fleets][service-managed-fleets] to run render jobs; these fleet hosts do not have any rendering applications pre-installed. The standard way of installing applications is described [in the service documentation](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/provide-applications.html).
 
-**Licensing Requirements**: VRED requires valid BYOL licenses on all worker nodes. You must configure your license
-server to be accessible from your render farm, ensuring that licenses are available for concurrent rendering tasks.
+**Licensing Requirements**: VRED requires valid BYOL licenses on all worker nodes. You must configure your license server to be accessible from your render farm, ensuring that licenses are available for concurrent rendering tasks.
 
 ## Submitter Interfaces
 
-The VRED Submitter provides multiple interfaces for configuring render jobs. These interfaces will vary slightly
-since the values for certain settings (including animation clips and viewpoints/cameras) are only known during runtime
-(within VRED).
+The VRED Submitter provides multiple interfaces for configuring render jobs. These interfaces will vary slightly since the values for certain settings (including animation clips and viewpoints/cameras) are only known during runtime (within VRED).
 
 ### Submitter GUI (within VRED)
 
-Settings applied in this interface will persist for the entire duration that a given scene file is open (this includes
-closing and reopening the Submitter window). Initial settings in the Submitter UI are populated from VRED's general
-render options (which are saved in the scene file). Saving the scene file won't persist the Submitter UI options, but
-certain options (including frame range to render) will be repopulated if saved in VRED's general render settings.
+Settings applied in this interface will persist for the entire duration that a given scene file is open (this includes closing and reopening the Submitter window). Initial settings in the Submitter UI are populated from VRED's general render options (which are saved in the scene file). Saving the scene file won't persist the Submitter UI options, but certain options (including frame range to render) will be repopulated if saved in VRED's general render settings.
 
 ![VRED Submitter Dialog](VRED-Submitter-Dialog.png)
 
@@ -227,30 +117,22 @@ Below are descriptions of the options available in both of the above interfaces.
 
 ### Animation Options
 
-- **Render Animation**: If checked, allows specifying an animation type (which can also include a specific animation
-  clip), corresponding frame range and frames per task.
+- **Render Animation**: If checked, allows specifying an animation type (which can also include a specific animation clip), corresponding frame range and frames per task.
 - **Animation Type**: The type of animation (Clip or Timeline).
 - **Animation Clip**: The name of the animation clip to render
-- **Frame Range (Start Frame, End Frame, Frame Step)**: Start and end frames with optional step size. (format:
-  'a', 'a-b', or 'a-bxn', where 'a' is the start frame, 'b' is the end frame, and 'n' is the frame step). Negative
-  frames are supported.
+- **Frame Range (Start Frame, End Frame, Frame Step)**: Start and end frames with optional step size. (format: 'a', 'a-b', or 'a-bxn', where 'a' is the start frame, 'b' is the end frame, and 'n' is the frame step). Negative frames are supported.
 - **Frames Per Task**: The number of frames that will be rendered at a time for each task within a render job.
 
 ### Tiling Settings
 
-- **Enable Region Rendering**: When enabled, the rendered output image will be divided into multiple tiles
-  (subregions) that are first rendered as separate tasks for a given frame. These tiles will then be assembled
-  (combined) into one output image for a given frame (in a separate step).
+- **Enable Region Rendering**: When enabled, the rendered output image will be divided into multiple tiles (subregions) that are first rendered as separate tasks for a given frame. These tiles will then be assembled (combined) into one output image for a given frame (in a separate step).
 - **Tiles in X/Y**: Number of horizontal/vertical tiles to divide the specified rendered output image for a given frame
 
-**Important**: Region rendering (tiling) is designed for scene files that have been configured for Raytracing.
-Raytracing will automatically be enabled when using this setting. Applying region rendering to scene files that aren't
-configured for Raytracing may result in solid black-rendered output.
+**Important**: Region rendering (tiling) is designed for scene files that have been configured for Raytracing. Raytracing will automatically be enabled when using this setting. Applying region rendering to scene files that aren't configured for Raytracing may result in solid black-rendered output.
 
 ### Invoking the Standalone Submitter
 
-The standalone submitter is invoked via command line and relies on the following environment variables, which you can
-substitute with appropriate values:
+The standalone submitter is invoked via command line and relies on the following environment variables, which you can substitute with appropriate values:
 
 ```bash
 # Windows
@@ -268,26 +150,15 @@ deadline bundle gui-submit .
 
 ## Viewing/Submitting a Job Bundle
 
-Before submitting a render job, the Submitter first generates a [Job Bundle][job-bundle], and then relies on the
-[AWS Deadline Cloud Client][deadline-cloud-client] package to submit that Job Bundle to a specified render farm. If you
-would like to examine that job bundle, then you can use the `Export Bundle` button in the Submitter to export the Job
-Bundle to a location of your choice. If you want to submit the exported Job Bundle manually outside VRED, then you
-can use the Standalone [AWS Deadline Cloud Client][deadline-cloud-client] to submit that same Job Bundle to your
-specified render farm in a platform-agnostic manner.
+Before submitting a render job, the Submitter first generates a [Job Bundle][job-bundle], and then relies on the [AWS Deadline Cloud Client][deadline-cloud-client] package to submit that Job Bundle to a specified render farm. If you would like to examine that job bundle, then you can use the `Export Bundle` button in the Submitter to export the Job Bundle to a location of your choice. If you want to submit the exported Job Bundle manually outside VRED, then you can use the Standalone [AWS Deadline Cloud Client][deadline-cloud-client] to submit that same Job Bundle to your specified render farm in a platform-agnostic manner.
 
-Standalone [AWS Deadline Cloud Client][deadline-cloud-client] render jobs should use the appropriate Job Bundle
-Template obtained through this [link][job-bundle-templates]. There, you will find one Job Bundle Template for
-supporting tile-based rendering (tile_render_vred/template.yaml) and another Job Bundle Template for non-tile rendering
-(vred_render/template.yaml). When submitting a render job that doesn't rely on tiling, you can use the standard job
-Please also ensure that your Job Bundle directory has a `scripts` subdirectory containing
-`VRED_RenderScript_DeadlineCloud.py`, which is a required pipeline rendering component for the job bundle. You
-should also include `parameter_values.yaml` (values for the fields defined in the Job Bundle Template) and
-`asset_references.yaml` (for defining file dependencies).
+Standalone [AWS Deadline Cloud Client][deadline-cloud-client] render jobs should use the appropriate Job Bundle Template obtained through this [link][job-bundle-templates]. There, you will find one Job Bundle Template for supporting tile-based rendering (tile_render_vred/template.yaml) and another Job Bundle Template for non-tile rendering (vred_render/template.yaml). When submitting a render job that doesn't rely on tiling, you can use the standard job.
+
+Please also ensure that your Job Bundle directory has a `scripts` subdirectory containing `VRED_RenderScript_DeadlineCloud.py`, which is a required pipeline rendering component for the job bundle. You should also include `parameter_values.yaml` (values for the fields defined in the Job Bundle Template) and `asset_references.yaml` (for defining file dependencies).
 
 ## Optional: Worker Setup - Customer Managed Fleet (CMF) (for Windows and Linux only)
 
-While using AWS' Service Managed Fleet (SMF) is highly recommended, you can also set up a customer managed fleet (CMF)
-worker for your own farm using the steps below:
+While using AWS' Service Managed Fleet (SMF) is highly recommended, you can also set up a customer managed fleet (CMF) worker for your own farm using the steps below:
 
 1. Create your own farm in the AWS Console (under the `AWS Deadline Cloud` service). Note the Farm ID, Fleet ID, and
    AWS Region (substituting them in step 3).
@@ -372,10 +243,7 @@ yum install fontconfig libX11 fribidi  # or dnf install fontconfig libX11 fribid
 export MAGICK=$PWD/magick
 ```
 
-You can also add these steps (above) to an existing Conda package (or make another one) and reference that package's
-name in the render job submission (under the `Conda Packages` setting). At the time of writing, Customer
-Managed Fleet (CMF) instances only support tiling since there isn't yet an official Conda package that provides
-a static ImageMagick binary (including dependencies) on Linux. However, it is possible to create that Conda package.
+You can also add these steps (above) to an existing Conda package (or make another one) and reference that package's name in the render job submission (under the `Conda Packages` setting). At the time of writing, Customer Managed Fleet (CMF) instances only support tiling since there isn't yet an official Conda package that provides a static ImageMagick binary (including dependencies) on Linux. However, it is possible to create that Conda package.
 
 **IMPORTANT**: Without ImageMagick, tile assembly will fail and region rendering jobs will not complete successfully.
 
@@ -410,10 +278,7 @@ One of these environment variables must be set:
 
 ## Troubleshooting
 
-In general, the AWS Deadline Cloud Monitor provides valuable insights into the activities that occurred while a worker
-node was processing a VRED scene file. Logs from these activities can be generated and shared with support teams. 
-Depending on the scope/nature of an issue, there may be additional avenues worth investigating. Below are 
-suggestions.
+In general, the AWS Deadline Cloud Monitor provides valuable insights into the activities that occurred while a worker node was processing a VRED scene file. Logs from these activities can be generated and shared with support teams. Depending on the scope/nature of an issue, there may be additional avenues worth investigating. Below are suggestions.
 
 ### Common Issues
 
@@ -489,19 +354,25 @@ suggestions.
    - Try changing the tone mapper and all Color Space/Range-related settings to the sRGB/Reinhard/Linear color space. 
    - Use a compatible/hardware qualified NVIDIA driver level (553.xx)
    - Consider distributing ICC monitor profile (if necessary) per Autodesk recommendations
+
+## Versioning
+
+This package's version follows [Semantic Versioning 2.0](https://semver.org/), but it is still considered to be in its initial development, thus backwards incompatible versions are denoted by minor version bumps. To help illustrate how versions will increment during this initial development stage, they are described below:
+
+1. The MAJOR version is currently 0, indicating initial development.
+2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API.
+3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the
+   public API.
    
 ## Security
 
 We take all security reports seriously. When we receive such reports, we will investigate and subsequently address any
 potential vulnerabilities as quickly as possible. If you discover a potential security issue in this project, please
-notify AWS/Amazon Security via
-our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/) or directly via email
-to [AWS Security](mailto:aws-security@amazon.com). Please do not create a public GitHub issue in this project.
+notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/) or directly via email to [AWS Security](mailto:aws-security@amazon.com). Please do not create a public GitHub issue in this project.
 
 ## Telemetry
 
-See [telemetry](https://github.com/aws-deadline/deadline-cloud-for-vred/blob/release/docs/telemetry.md) for more
-information.
+See [telemetry](docs/telemetry.md) for more information.
 
 ## License
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need updated manual installation instructions

### What was the solution? (How)
Added them, and reorganized the docs a bit to be in line with other Deadline Cloud integration packages.

### What is the impact of this change?
Users should be able to know how to manually install the VRED submitter.

### How was this change tested?
Followed the instructions and confirmed I could submit a VRED job using these steps.

### Was this change documented?
Yes, in this change

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
