### PR TITLE
chore: Add release scripts in hatch.toml

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -65,6 +65,11 @@ SKIP_BOOTSTRAP_TEST_RESOURCES="True"
 [envs.release]
 detached = true
 
+[envs.release.scripts]
+deps = "pip install -r requirements-release.txt"
+bump = "semantic-release -v --strict version --no-push --no-commit --no-tag --skip-build {args}"
+version = "semantic-release -v --strict version --print {args}"
+
 [envs.installer.scripts]
 build-installer = "python {root}/scripts/build_installer_cli.py --installer-source-path {root}/installer/DeadlineCloudForVREDSubmitter.xml {args:}"
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
hatch.toml was missing some scripts required for release workflow

### What was the solution? (How)
Adding the required scripts

### What is the impact of this change?
We can run the release workflow

### How was this change tested?
N/A 

### Was this change documented?
N/A

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
