### PR TITLE
chore: Add semantic_release folder into repo

### DIFF
--- a/.semantic_release/CHANGELOG.md.j2
+++ b/.semantic_release/CHANGELOG.md.j2
@@ -1,0 +1,25 @@
+{% for version, release in context.history.released.items() %}
+## {{ version.as_tag() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
+
+    {% if "breaking" in release["elements"] %}
+### BREAKING CHANGES
+        {% for commit in release["elements"]["breaking"] %}
+* {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(": ")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+        {% endfor %}
+    {% endif %}
+
+    {% if "features" in release["elements"] %}
+### Features
+        {% for commit in release["elements"]["features"] %}
+* {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(": ")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+        {% endfor %}
+    {% endif %}
+
+    {% if "bug fixes" in release["elements"] %}
+### Bug Fixes
+        {% for commit in release["elements"]["bug fixes"] %}
+* {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(":")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+        {% endfor %}
+    {% endif %}
+
+{% endfor %}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The repo was missing [.semantic_release](https://github.com/aws-deadline/deadline-cloud-for-nuke/tree/mainline/.semantic_release) folder that is required for release workflow.

### What was the solution? (How)
Adding .semantic_release folder with CHANGELOG.md.j2

### What is the impact of this change?
We can run the release workflow

### How was this change tested?
N/A 

### Was this change documented?
N/A 

### Is this a breaking change?
N/A 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
