### PR TITLE
Rollback python-semantic-release version to 10.2.*

### DIFF
--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,1 +1,1 @@
-python-semantic-release == 10.3.*
+python-semantic-release == 10.2.*


### PR DESCRIPTION
### Summary
We need to roll back our dep on python-semantic-release to 10.2 as they have breaking changes blocking release, see https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst#v1030-2025-08-04

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
