### PR TITLE
chore: revert deadline dependency back to 0.50.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.11"
 description = "AWS Deadline Cloud for VRED"
 
 dependencies = [
-    "deadline == 0.51.*",
+    "deadline == 0.50.*",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There's an emergent bug in the deadline 0.51 release and we need to revert https://github.com/aws-deadline/deadline-cloud-for-vred/pull/39

### What was the solution? (How)
Reverted the changes from https://github.com/aws-deadline/deadline-cloud-for-vred/pull/39

### What is the impact of this change?
The submitter window will no longer hang open after job submissions

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
