### PR TITLE
chore!: add allow_zero_version to semantic_release config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ fail_under = 0
 # Can be removed or set to true once we are v1
 major_on_zero = false
 tag_format = "{version}"
+allow_zero_version = true
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When performing a release bump action we would get 1.x version which we do not prefer

### What was the solution? (How)
Enable zero version releases by adding allow_zero_version = true to the [tool.semantic_release] section in pyproject.toml

### What is the impact of this change?
Correct version bump

### How was this change tested?
N/A

### Is this a breaking change?
To make a proper version bump for a initial public release, We are intentionally making this commit as a breaking change.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
