### PR TITLE
chore: update deadline dependency to 0.51

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ __pycache__/
 /dev_install/
 /wheels/
 **/otls/backup
+/test/integ/output/
+/test/integ/scene_files/IncrementalSave_FileReferencing.vpb/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -274,7 +274,7 @@ For the instructions that follow, change the directory names as appropriate to c
     - `pip install --upgrade -r requirements-development.txt`
 1. Create submitter directory
     - run `hatch build` in your local git repository
-    - Windows: `xcopy -r src\deadline\vred_submitter\ ~%USERPROFILE%\DeadlineCloudSubmitter\Submitters\VRED\scripts\deadline\vred_submitter /s /e /h`
+    - Windows: `xcopy src\deadline\vred_submitter\ %USERPROFILE%\DeadlineCloudSubmitter\Submitters\VRED\scripts\deadline\vred_submitter\ /s /e /h`
 1. Install submitter dependencies:
     - Windows: `pip install --python-version 3.11 --only-binary=:all: "deadline[gui]" -t %USERPROFILE%\DeadlineCloudSubmitter\Submitters\VRED\python\modules`
 1. Set the `DEADLINE_VRED_MODULES` environment variable to point to your VRED module install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 
 dependencies = [
-    "deadline == 0.50.*",
+    "deadline >= 0.51.1,<0.52",
 ]
 
 [project.urls]

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/integ/README.md
+++ b/test/integ/README.md
@@ -2,6 +2,8 @@
 
 Comprehensive integration test suite for the VRED Deadline Cloud Submitter using pytest with real VRED application instances.
 
+This test requires opening VRED Pro and directly interacting with the Deadline Cloud submitter UI, so it can only be executed on a Windows system that supports VRED Pro.
+
 ## Directory Structure
 
 ```
@@ -29,21 +31,18 @@ vred_submitter/test/integ/
 - Python 3.10+
 - pytest 8.1.1+
 - PyYAML (for job bundle validation)
-- VRED 2025+ (VRED Core or VRED Pro)
+- VRED 2025+ (VRED Pro)
+- Deadline CLI, and VRED in-app submitter
 
-## Environment Setup
+### Environment Setup
 
-### VRED Installation
-Set one of these environment variables:
-```bash
-# Windows
-set VREDCORE=C:\Program Files\Autodesk\VREDPro-2024\bin\WIN64\VREDCore.exe
-# or
-set VREDPRO=C:\Program Files\Autodesk\VREDPro-2024\bin\WIN64\VREDPro.exe
+- Set one of these environment variables:
+   ```bash
+   # Windows
+   set VREDPRO=C:\Program Files\Autodesk\VREDPro-2024\bin\WIN64\VREDPro.exe
+   ```
 
-# Linux
-export VREDCORE=/opt/Autodesk/VREDCluster-2024/bin/VREDCore
-```
+- The tests use a hardcoded output directory path for the rendered images, which is set to `"C:\\vred-snapshots"`. Ensure that this path actually exists on the local where the test is being executed. Alternatively, replace the hardcoded path with a directory that does exist on the local.
 
 ### Dependencies
 ```bash
@@ -138,7 +137,7 @@ asset_overrides = [
 ## Environment Variables
 
 ### VRED Configuration
-- `VREDCORE` / `VREDPRO`: Path to VRED executable
+- `VREDPRO`: Path to VRED executable
 - `VRED_DISABLE_WEB_INTERFACE`: Disables web interface (set automatically)
 - `VRED_LICENSE_RELEASE_TIME`: License release timeout (set automatically)
 - `FLEXLM_DIAGNOSTICS`: FlexLM diagnostic level (set automatically)
@@ -154,7 +153,7 @@ asset_overrides = [
    ```
    OSError: VRED executable not found
    ```
-   - Verify VREDCORE or VREDPRO environment variable
+   - Verify VREDPRO environment variable
    - Check VRED installation path and permissions
 
 2. **Dialog Creation Failed**


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Dependabot updates to the deadline dependency were failing due to breaking changes in the latest release: [PR#60](https://github.com/aws-deadline/deadline-cloud-for-vred/pull/60)

### What was the solution? (How)
- Needed to update our `_create_job_bundle_callback` signature to return a `dict[str, Any]`. I looked at the previous PR where we had attempted to make this update: https://github.com/aws-deadline/deadline-cloud-for-vred/pull/39
- Also, to be able to run the integ tests on my Windows setup, created a new file integ/__init__.py, and updated README and one of the test scene files.

### What is the impact of this change?
We'll be up to date with the latest `deadline` CLI version

### How was this change tested?
- On Windows where deadline 0.51.0 library, VRED Pro 2026, and the in-app Submitter are installed, applied these changes of the PR (manually updated the installed file  `C:\Users\Administrator\DeadlineCloudSubmitter\Submitters\VRED\scripts\deadline\vred_submitter\vred_submitter.py`)
- Confirmed I could submit a job successfully from the submitter. Also, confirmed that the submitted jobs were rendered correctly.
- Ran integration test by `hatch run integ:test`, and confirmed all 3 tests passed. 

### Was this change documented?
No, we are just trying to update the dependency version.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
