### PR TITLE
feat: improve tile rendering setup and usability

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,7 +24,7 @@ To develop the Python code in this repository you will need:
 1. Python 3.11 or higher. We recommend [mise](https://github.com/jdx/mise) if you would like to run more than one version of Python on the same system. When running unit tests against all supported Python versions, for instance.
 2. The [hatch](https://github.com/pypa/hatch) package installed (`pip install hatch`) into your Python environment.
 3. A supported version of VRED Pro or VRED Core with valid bring your own licensing (BYOL).
-4. ImageMagick installed for tile assembly testing (download from [imagemagick.org](https://imagemagick.org/script/download.php)).
+4. (Optional) ImageMagick for tile assembly testing (download from [imagemagick.org](https://imagemagick.org/script/download.php)).
 5. A valid AWS Account.
 6. An AWS Deadline Cloud Farm to run jobs on. We recommend following the quickstart in the Deadline Cloud console to create a Queue with the default Queue Environment, and a Service Managed Fleet.
 
@@ -165,6 +165,7 @@ We have configured [hatch](https://github.com/pypa/hatch) commands to support st
 * `hatch run all:test` - To run the PyTest unit tests against all available supported versions of Python.
 * `hatch run lint` - To check that the package's formatting adheres to formatting standards.
 * `hatch run fmt` - To automatically reformat all code to adhere to formatting standards.
+* `hatch clean` - To remove build artifacts associated with a project
 * `hatch env prune` - Delete all of your isolated workspace [environments](https://hatch.pypa.io/1.12/environment/) for this package.
 
 Note: Hatch uses [environments](https://hatch.pypa.io/1.12/environment/) to isolate the Python development workspace for this package from your system or virtual environment Python. If your build/test run is not making sense, then sometimes pruning (`hatch env prune`) all of these environments for the package can fix the issue.
@@ -226,36 +227,12 @@ hatch run worker:test
 
 ##### Integration Tests
 
-Integration tests are located under the `test/integ` directory. These tests verify that the submitter generates correct job bundles and that the VRED render script functions properly.
+Integration tests are located under the `test/integ` directory. These tests verify that the submitter UI functions correctly and generates valid job bundles. These tests do not perform actual rendering - they focus on UI automation and job bundle validation.
 
-To run the integration tests:
+**To run the integration tests**: please see [README in integ folder](test/integ/README.md).
 
-1. Ensure VRED is installed and the `VREDCORE` or `VREDPRO` environment variable is set:
-   ```cmd
-   set VREDCORE=C:\Program Files\Autodesk\VREDCore-18.0\bin\WIN64\VREDCore.exe
-   ```
-   or
-   ```cmd
-   set VREDPRO=C:\Program Files\Autodesk\VREDPro-18.0\bin\WIN64\VREDPro.exe
-   ```
 
-2. Run the integration tests:
-   ```bash
-   hatch run integ:test
-   ```
-
-The integration tests include:
-
-- **Basic render tests** - Verify that single frame rendering with basic settings
-- **Tiling tests** - Test render region assembly via ImageMagick across multiple tiles
-- **Asset reference tests** - Validate scene asset dependency detection
-- **Bundle comparison tests** - Compare generated job bundles against expected output
-
-##### Test Configuration
-
-Integration tests use scene files located in `test/integ/scene_files/` and compare output against expected baselines in `test/integ/expected_output/`. Test parameters can be customized through parameter and asset overrides in the test configuration.
-
-### Manual Installation
+### How To Install Submitter Manually
 #### Prerequisites
 
 1. Install the required applications:
@@ -320,8 +297,8 @@ For the instructions that follow, change the directory names as appropriate to c
 
 ### Required for Tile Assembly
 
-- `MAGICK`: Path to ImageMagick executable (e.g., `C:\Program Files\ImageMagick-7.1.1-Q16\magick.exe`)
-    - **Required** for region rendering tests and tile assembly functionality
+- `MAGICK`: (Optional) Path to ImageMagick executable (e.g., `C:\Program Files\ImageMagick-7.1.1-Q16\magick.exe`)
+    - If not set, the system will use the default `magick` command from PATH
     - Download from [https://imagemagick.org/script/download.php](https://imagemagick.org/script/download.php)
     - Install 64-bit static release for best compatibility
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ AWS Deadline Cloud for VRED is a Python-based package that supports creating and
 
 [vred-requirements]: https://www.autodesk.com/support/technical/article/caas/sfdcarticles/sfdcarticles/System-requirements-for-Autodesk-VRED-2026-products.html
 
-## Compatibility
+## Requirements
 
 The AWS Deadline Cloud for VRED package requires:
 
@@ -47,7 +47,7 @@ Before submitting any large, complex, or otherwise compute-heavy VRED render job
 
 If you have installed the submitter using the Deadline Cloud submitter installer you can follow the guide to [Setup Deadline Cloud submitters](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html#load-dca-plugin) for the manual steps needed after installation.
 
-If you are setting up the submitter for a developer workflow or manual installation you can follow the instructions in the [DEVELOPMENT](DEVELOPMENT.md#manual-installation) file.
+If you are setting up the submitter for a developer workflow or manual installation you can follow the instructions in the [DEVELOPMENT](DEVELOPMENT.md#how-to-install-submitter-manually) file.
 
 ### VRED Submitter Plug-in
 
@@ -122,7 +122,9 @@ Below are descriptions of the options available in both of the above interfaces.
 - **Enable Region Rendering**: When enabled, the rendered output image will be divided into multiple tiles (subregions) that are first rendered as separate tasks for a given frame. These tiles will then be assembled (combined) into one output image for a given frame (in a separate step).
 - **Tiles in X/Y**: Number of horizontal/vertical tiles to divide the specified rendered output image for a given frame
 
-**Important**: Region rendering (tiling) is designed for scene files that have been configured for Raytracing. Raytracing will automatically be enabled when using this setting. Applying region rendering to scene files that aren't configured for Raytracing may result in solid black-rendered output.
+**Note**: Region rendering (tiling) is designed for scene files that have been configured for Raytracing. When you enable "Enable Region Rendering", the "Use GPU Ray Tracing" option will be automatically enabled to ensure proper tile rendering. Applying region rendering to scene files that aren't configured for Raytracing may result in solid black-rendered output.
+
+**How to use Tile Rendering with Service Managed Fleet (SMF)**: To use tile rendering with SMF, add the `imagemagick` conda package from the `conda-forge` channel to your Queue Environment. This provides the ImageMagick binary needed for tile assembly. For detailed instructions on configuring conda packages, see [Configure jobs using queue environments](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs.html). Once configured, simply enable "Enable Region Rendering" in the submitter ("Use GPU Ray Tracing" will be automatically enabled) and submit your job.
 
 ### Invoking the Standalone Submitter
 
@@ -146,7 +148,7 @@ deadline bundle gui-submit .
 
 Before submitting a render job, the Submitter first generates a [Job Bundle][job-bundle], and then relies on the [AWS Deadline Cloud Client][deadline-cloud-client] package to submit that Job Bundle to a specified render farm. If you would like to examine that job bundle, then you can use the `Export Bundle` button in the Submitter to export the Job Bundle to a location of your choice. If you want to submit the exported Job Bundle manually outside VRED, then you can use the Standalone [AWS Deadline Cloud Client][deadline-cloud-client] to submit that same Job Bundle to your specified render farm in a platform-agnostic manner.
 
-Standalone [AWS Deadline Cloud Client][deadline-cloud-client] render jobs should use the appropriate Job Bundle Template obtained through this [link][job-bundle-templates]. There, you will find one Job Bundle Template for supporting tile-based rendering (tile_render_vred/template.yaml) and another Job Bundle Template for non-tile rendering (vred_render/template.yaml). When submitting a render job that doesn't rely on tiling, you can use the standard job.
+Standalone [AWS Deadline Cloud Client][deadline-cloud-client] render jobs should use the appropriate Job Bundle Template obtained through this [link][job-bundle-templates]. There, you will find one Job Bundle Template for supporting tile-based rendering (template.yaml) and another Job Bundle Template for non-tile rendering (template_tiling.yaml). When submitting a render job that doesn't rely on tiling, you can use the standard job.
 
 Please also ensure that your Job Bundle directory has a `scripts` subdirectory containing `VRED_RenderScript_DeadlineCloud.py`, which is a required pipeline rendering component for the job bundle. You should also include `parameter_values.yaml` (values for the fields defined in the Job Bundle Template) and `asset_references.yaml` (for defining file dependencies).
 
@@ -210,17 +212,19 @@ While using AWS' Service Managed Fleet (SMF) is highly recommended, you can also
 
 ## [ImageMagick Installation](#imagemagick-installation)
 
-For render jobs using region rendering (tiling), ImageMagick must be installed on the worker nodes:
+For render jobs using region rendering (tiling), ImageMagick must be available on the worker nodes. Install ImageMagick so the `magick` command is available in the system PATH. Or, set the `MAGICK` environment variable to point to a specific ImageMagick executable.
 
 ### Windows
 
 1. Visit the ImageMagick downloads
    page [https://imagemagick.org/script/download.php](https://imagemagick.org/script/download.php)
 2. Download and install the 64-bit static binary release
-3. Set the `MAGICK` environment variable as appropriate (depending on installation path/version):
-   ```cmd
-   setx MAGICK "C:\Program Files\ImageMagick-7.1.1-Q16\magick.exe"
-   ```
+3. Choose one of the following options:
+   - **Option A**: Add ImageMagick to your system PATH so `magick` command is available globally
+   - **Option B**: Set the `MAGICK` environment variable to point to the specific executable:
+     ```cmd
+     setx MAGICK "C:\Program Files\ImageMagick-7.1.1-Q16\magick.exe"
+     ```
 4. Logout, login.
 
 ### Linux
@@ -268,7 +272,7 @@ One of these environment variables must be set:
 
 ### Environment Variables for Tile Assembly
 
-- `MAGICK`: Path to ImageMagick static binary executable (required for region rendering jobs)
+- `MAGICK`: (Optional) Path to ImageMagick binary executable (required for region rendering jobs). If not set, the default `magick` command from PATH will be used.
 
 ## Troubleshooting
 
@@ -306,7 +310,9 @@ In general, the AWS Deadline Cloud Monitor provides valuable insights into the a
           requirements configuration.
 
 5. **Tile Assembly Failed**
-    - Verify that ImageMagick is installed and that the `MAGICK` environment variable is set on the worker node
+    - Verify that ImageMagick is installed and accessible either via:
+        - The `magick` command in system PATH, or
+        - The `MAGICK` environment variable pointing to the executable
     - Check ImageMagick executable permissions
     - Ensure sufficient disk space for tile processing
 

--- a/src/deadline/vred_submitter/default_vred_job_template.yaml
+++ b/src/deadline/vred_submitter/default_vred_job_template.yaml
@@ -430,7 +430,7 @@ steps:
           data: |-
             from typing import Any, Dict
 
-            def str_to_bool(s:str)->bool: return s.lower() == 'true'
+            def str_to_bool(s:str) -> bool: return s.lower() == 'true'
 
             def get_vred_render_parameters() -> Dict[str, Any]:
                 """
@@ -645,10 +645,14 @@ steps:
           import platform
           import subprocess
 
-          END_FRAME = int("{{Param.EndFrame}}")
-          EVALUATE_SEQUENCE_PARAM = "-evaluate-sequence max"
           IS_WINDOWS = platform.system().lower() == "windows"
-          MAGICK_BIN = os.path.normpath(os.environ.get("MAGICK") or "").replace("\\", "/")
+
+          # Path to the ImageMagick binary, either by using the "MAGICK" env variable if it's set, 
+          # or by defaulting to the "magick" command
+          MAGICK_BIN = os.path.normpath(os.environ.get("MAGICK") or "magick").replace("\\", "/")
+
+          EVALUATE_SEQUENCE_PARAM = "-evaluate-sequence"
+          EVALUATE_SEQUENCE_PARAM_VALUE = "max"
           MIN_WORKERS_IF_UNKNOWN = 4
           NUM_X_TILES = int("{{Param.NumXTiles}}")
           NUM_Y_TILES = int("{{Param.NumYTiles}}")
@@ -656,30 +660,42 @@ steps:
           OUTPUT_FILE_PREFIX = "{{Param.OutputFileNamePrefix}}"
           OUTPUT_FORMAT = "{{Param.OutputFormat}}".lower()
           START_FRAME = int("{{Param.StartFrame}}")
+          END_FRAME = int("{{Param.EndFrame}}")
+          IS_RENDER_ANIMATION = "{{Param.RenderAnimation}}".lower() == "true"
 
           def assemble_frame(frame_num: int) -> None:
               """
-              Assembles a given frame from the tiles that comprise it. Filename format: prefix_YxX_AxB.suffix.
-              Assumes that output folder contains tiles in sequential order: left to right from top to bottom.
-              :param: frame_num: frame number
+              Assembles a given frame from the tiles that comprise it.
+              When "Render Animation" is enabled, VRED appends frame numbers to output filenames,
+              so we need to account for this in both input and output filename formats.
+
+              Filename formats:
+              - Single frame: prefix_YxX_AxB.suffix -> prefix.suffix
+              - Animation (multiple frames): prefix_YxX_AxB-NNNNN.suffix -> prefix-NNNNN.suffix
               """
-              frame_str = f"{frame_num:05d}"
-              # Note: tile value is not [rows]x[columns]; it is [columns]x[rows]
+
+              # Note: tile value is [columns count]x[rows count]
               tile_value = f"{NUM_X_TILES}x{NUM_Y_TILES}"
-              input_file_mask = rf"{OUTPUT_DIR}/*_{tile_value}-{frame_str}.*"
-              output_file = rf"{OUTPUT_DIR}/{OUTPUT_FILE_PREFIX}-{frame_str}.{OUTPUT_FORMAT}"
+              frame_suffix = f"-{frame_num:05d}" if IS_RENDER_ANIMATION else ""
+              input_file_mask = f"{OUTPUT_DIR}/*_{tile_value}{frame_suffix}.{OUTPUT_FORMAT}"
+              output_file = f"{OUTPUT_DIR}/{OUTPUT_FILE_PREFIX}{frame_suffix}.{OUTPUT_FORMAT}"              
+
               command_and_arg_list: list[str] = [
                   MAGICK_BIN,
                   input_file_mask,
                   EVALUATE_SEQUENCE_PARAM,
+                  EVALUATE_SEQUENCE_PARAM_VALUE,
                   output_file,
               ]
+
               try:
                   invocation = " ".join(command_and_arg_list) if IS_WINDOWS else command_and_arg_list
-                  output = subprocess.run(invocation, stderr=subprocess.STDOUT, check=True, text=True)
-                  print(output)
+                  result = subprocess.run(invocation, capture_output=True, check=True, text=True)
+                  print(f"command invocation result: {result}")
               except subprocess.CalledProcessError as error:
-                  print(f"Command: [{invocation}] failed: \n{error.output}\n with return code {error.returncode}")
+                  print(f"Command: {invocation} failed with return code {error.returncode}")
+                  print(f"--------------- STDOUT ---------------\n{error.stdout}")
+                  print(f"--------------- STDERR ---------------\n{error.stderr}")
 
           # Parallel processing of frames
           max_workers = os.cpu_count() or MIN_WORKERS_IF_UNKNOWN

--- a/src/deadline/vred_submitter/ui/components/scene_settings_callbacks.py
+++ b/src/deadline/vred_submitter/ui/components/scene_settings_callbacks.py
@@ -261,11 +261,23 @@ class SceneSettingsCallbacks:
     def enable_region_rendering_changed_callback(self) -> None:
         """
         Updates UI elements when region rendering is enabled/disabled.
+        When region rendering is enabled, GPU Ray Tracing is automatically enabled and disabled.
         """
         if not self.parent.init_complete:
             return
         state = self.parent.enable_region_rendering_widget.isChecked()
         self.parent.populator.persisted_ui_settings_states.enable_render_regions = state
+
+        # When region rendering is enabled, auto-enable GPU Ray Tracing and disable the control.
+        # Region rendering requires GPU Ray Tracing to ensure proper tile rendering,
+        # so we disable the control to prevent users from accidentally turning it off.
+        # When region rendering is disabled, re-enable the GPU Ray Tracing control.
+        if state:
+            self.parent.gpu_ray_tracing_widget.setChecked(True)
+            self.parent.gpu_ray_tracing_widget.setEnabled(False)
+        else:
+            self.parent.gpu_ray_tracing_widget.setEnabled(True)
+
         # All UI elements that should be enabled/disabled together
         region_rendering_controls = [
             self.parent.tiles_in_x_label,

--- a/test/integ/README.md
+++ b/test/integ/README.md
@@ -2,7 +2,18 @@
 
 Comprehensive integration test suite for the VRED Deadline Cloud Submitter using pytest with real VRED application instances.
 
-This test requires opening VRED Pro and directly interacting with the Deadline Cloud submitter UI, so it can only be executed on a Windows system that supports VRED Pro.
+**Test Process**: Each test opens VRED Pro, loads a test scene, applies specific settings through the submitter dialog, exports a job bundle, and validates the bundle contents against expected output files.
+Integration tests use scene files located in `test/integ/scene_files/` and compare output against expected baselines in `test/integ/expected_output/`. Test parameters can be customized through parameter and asset overrides in the test configuration.
+
+The integration tests include:
+
+- **Job bundle generation tests** - Verify that VRED submitter UI can generate valid job bundles with correct structure
+- **UI settings application tests** - Validate that various render settings are properly applied through Qt dialog automation
+- **Asset reference validation tests** - Ensure scene asset dependencies are correctly detected and included in job bundles
+- **Parameter comparison tests** - Compare generated parameter values against expected baselines for different render configurations
+
+**Note**: This test requires opening VRED Pro and directly interacting with the Deadline Cloud submitter UI, so it can only be executed on a Windows system that supports VRED Pro.
+
 
 ## Directory Structure
 

--- a/test/integ/output_comparison.py
+++ b/test/integ/output_comparison.py
@@ -46,10 +46,13 @@ def assert_parameter_values_similar(
         expected = expected_parameter_values[Constants.PARAMETER_VALUES_FIELD]
         assert len(actual) == len(expected)
         for param in expected:
-            name, value = param[Constants.NAME_FIELD], param[Constants.VALUE_FIELD]
-            assert value == extract_parameter_value(
-                {Constants.PARAMETER_VALUES_FIELD: actual}, name
+            param_name, expected_value = param[Constants.NAME_FIELD], param[Constants.VALUE_FIELD]
+            actual_value = extract_parameter_value(
+                {Constants.PARAMETER_VALUES_FIELD: actual}, param_name
             )
+            assert (
+                expected_value == actual_value
+            ), f"\nParameter '{param_name}':\n  Expected: {expected_value}\n  Actual: {actual_value}"
 
 
 def assert_asset_references_similar(

--- a/test/integ/submitter_dialog_controller.py
+++ b/test/integ/submitter_dialog_controller.py
@@ -102,6 +102,8 @@ class SubmitterDialogController:
                 self.scene_settings_widget.frames_per_task_widget.setValue(
                     settings["FramesPerTask"]
                 )
+            # Note: GPU Ray Tracing will be automatically enabled when Region Rendering is enabled
+            # This setting will only take effect if Region Rendering is disabled
             if "GPURaytracing" in settings:
                 self.scene_settings_widget.gpu_ray_tracing_widget.setChecked(
                     settings["GPURaytracing"] == "true"
@@ -130,6 +132,7 @@ class SubmitterDialogController:
                 output_path = f"{settings['OutputDir']}/{prefix}.{format_ext}"
                 self.scene_settings_widget.render_output_widget.clear()
                 self.scene_settings_widget.render_output_widget.setText(output_path)
+            # Note: If Region Rendering is enabled, GPU Ray Tracing is also automatically enabled
             if "RegionRendering" in settings:
                 self.scene_settings_widget.enable_region_rendering_widget.setChecked(
                     settings["RegionRendering"] == "true"

--- a/test/unit/test_ui_components_scene_settings_callbacks.py
+++ b/test/unit/test_ui_components_scene_settings_callbacks.py
@@ -120,10 +120,32 @@ class TestSceneSettingsCallbacks:
         callbacks.enable_region_rendering_changed_callback()
 
         assert mock_parent.populator.persisted_ui_settings_states.enable_render_regions
+        # Verify GPU Ray Tracing is automatically enabled and disabled
+        mock_parent.gpu_ray_tracing_widget.setChecked.assert_called_with(True)
+        mock_parent.gpu_ray_tracing_widget.setEnabled.assert_called_with(False)
+        # Verify tiling controls are enabled
         mock_parent.tiles_in_x_label.setEnabled.assert_called_with(True)
         mock_parent.tiles_in_x_widget.setEnabled.assert_called_with(True)
         mock_parent.tiles_in_y_label.setEnabled.assert_called_with(True)
         mock_parent.tiles_in_y_widget.setEnabled.assert_called_with(True)
+
+    def test_enable_region_rendering_changed_callback_disabled(self, callbacks, mock_parent):
+        mock_parent.enable_region_rendering_widget.isChecked.return_value = False
+        mock_parent.tiles_in_x_label = Mock()
+        mock_parent.tiles_in_x_widget = Mock()
+        mock_parent.tiles_in_y_label = Mock()
+        mock_parent.tiles_in_y_widget = Mock()
+
+        callbacks.enable_region_rendering_changed_callback()
+
+        assert not mock_parent.populator.persisted_ui_settings_states.enable_render_regions
+        # Verify GPU Ray Tracing control is re-enabled
+        mock_parent.gpu_ray_tracing_widget.setEnabled.assert_called_with(True)
+        # Verify tiling controls are disabled
+        mock_parent.tiles_in_x_label.setEnabled.assert_called_with(False)
+        mock_parent.tiles_in_x_widget.setEnabled.assert_called_with(False)
+        mock_parent.tiles_in_y_label.setEnabled.assert_called_with(False)
+        mock_parent.tiles_in_y_widget.setEnabled.assert_called_with(False)
 
     @patch("vred_submitter.ui.components.scene_settings_callbacks.is_all_numbers")
     def test_image_size_text_changed_callback_valid_numbers(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The tile/region rendering feature had a couple of issues that created barriers to successful setup and usage.

1. Automatic GPU Ray Tracing Enablement: When using tile/region rendering, GPU ray tracing is a required setting, but users had to manually enable it in the submitter UI. 

2. Tile Assembly Configuration: The tile assembly process relied on the `MAGICK` environment variable being set to the correct ImageMagick executable path, which is an extra configuration step that we can make as an optional.

3. Multiple Frame Handling: When the "Render Animation" option was enabled, the tile image filenames followed a different pattern compared to single-frame (when "Render Animation" is disabled) renders. However, the tile assembly script did not properly handle these different file naming.

### What was the solution? (How)

These changes aim to improve the overall usability and reliability of the tile rendering feature.

1. Automatically enable "Enable GPU Ray Tracing" option when region (tile) rendering is enabled, as this is required for proper tile rendering. Previously, the user had to manually enable GPU ray tracing.

2. Simplify the configuration for tile assembly by using the default `magick` command from the system PATH, rather than requiring the `MAGICK` environment variable to be set. The `MAGICK` variable is still supported as an option.

3. Update the `default_vred_job_template.yaml` file 
   - Handle differences in tile image file naming when the "Render Animation" option is enabled vs. disabled. When "Render Animation" is enabled, VRED appends frame numbers to the output filenames. The tile assembly script has been updated to account for this.

5. Update the docs and test configurations to reflect the changes

6. Update the tests to better validate the tile rendering workflow, including testing the automatic enabling of GPU ray tracing.

### What is the impact of this change?
Enhanced usability, better documentation

### How was this change tested?
- Ran unit tests and made sure all passed.
- Ran integ tests. To make the tiling rendering test pass, Needed to update the test expectations to correctly reflect the actual UI behaviour - when Region Rendering is enabled, the expected GPU Ray Tracing value should be set to 'true'. 

### Was this change documented?
Yes, please see the updates in README.md and DEVELOPMENT.md

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
