### PR TITLE
feat: Adds sticky settings to the submitter

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,16 +26,11 @@ Please ensure that you have read through the [contributing guidelines](https://g
 
 *delete text starting here*
 A breaking change is one that modifies a public contract in some way or otherwise changes functionality of this application in a way
-that is not backwards compatible. Examples of changes that are breaking include:
-
-1. Adding a new required value to the init-data or run-data of the adaptor;
-2. Deleting or renaming a value in the init-data or run-data of the adaptor; and
-3. Otherwise modifying the interface of the adaptor such that a job submitted with an older version of the Unreal submitter plug-in
-   will not work with a version of the adaptor that includes your modification.
+that is not backwards compatible.
 
 If so, then please describe the changes that users of this package must make to update their scripts, or Python applications. Also,
 please ensure that the title of your commit follows our conventional commit guidelines in
-[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
+[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-vred/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
 *delete text ending here*
 
 ----

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ __pycache__/
 **/otls/backup
 /test/integ/output/
 /test/integ/scene_files/IncrementalSave_FileReferencing.vpb/
+/test/integ/scene_files/*.deadline_render_settings.json
+test/worker/output/

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The VRED Submitter provides multiple interfaces for configuring render jobs. The
 
 Settings applied in this interface will persist for the entire duration that a given scene file is open (this includes closing and reopening the Submitter window). Initial settings in the Submitter UI are populated from VRED's general render options (which are saved in the scene file). Saving the scene file won't persist the Submitter UI options, but certain options (including frame range to render) will be repopulated if saved in VRED's general render settings.
 
+Once a job has been submitted, a local Deadline settings file will be saved next to the submitted scene file with the file name `<SceneName>.deadline_render_settings.json`. This file defines some submission options that will be reloaded for this scene the next time you open the submitter window.
+
 ![VRED Submitter Dialog](VRED-Submitter-Dialog.png)
 
 ### Standalone Submitter (external to VRED)

--- a/src/deadline/vred_submitter/constants.py
+++ b/src/deadline/vred_submitter/constants.py
@@ -82,6 +82,7 @@ class Constants(metaclass=ConstantsMeta):
     PARAMETER_VALUES_FILENAME: Final[str] = "parameter_values.yaml"
     POSITIVE_INFINITY: Final[str] = "inf"
     READ_FLAG: Final[str] = "r"
+    RENDER_SUBMITTER_SETTINGS_FILE_EXT = ".deadline_render_settings.json"
     SCENE_FILE_NOT_SAVED_TITLE: Final[str] = "Warning: scene file not saved"
     SCENE_FILE_NOT_SAVED_BODY: Final[str] = (
         "The scene file has unsaved local changes that will not be included in the job "

--- a/src/deadline/vred_submitter/data_classes.py
+++ b/src/deadline/vred_submitter/data_classes.py
@@ -6,10 +6,18 @@ This module include parameter field definitions, job parameter containers, UI-ba
 (for transporting render parameters and their values).
 """
 
+import dataclasses
+import json
 import os
-
+import traceback
 from dataclasses import dataclass, field
 from pathlib import Path
+
+from .constants import Constants
+from .vred_logger import get_logger
+
+
+_global_logger = get_logger(__name__)
 
 
 @dataclass
@@ -21,43 +29,105 @@ class RenderSubmitterUISettings:
     Note: values set to False might not be exposed in the submitter UI, but are exposed in the stock UI and backend
     """
 
-    # Internal settings
+    # Shared settings
     #
-    description: str = field(default="")
-    input_filenames: list[str] = field(default_factory=list)
-    input_directories: list[str] = field(default_factory=list)
+    description: str = field(default="", metadata={"sticky": True})
+    input_filenames: list[str] = field(default_factory=list, metadata={"sticky": True})
+    input_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
     JobScriptDir: str = field(default=os.path.normpath(os.path.join(Path(__file__).parent)))
-    name: str = field(default="")
-    output_directories: list[str] = field(default_factory=list)
+    name: str = field(default="", metadata={"sticky": True})
+    output_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
+    priority: int = field(default=50, metadata={"sticky": True})
     submitter_name: str = field(default="VRED")
+    initial_status: str = field(default="READY", metadata={"sticky": True})
+    max_failed_tasks_count: int = field(default=20, metadata={"sticky": True})
+    max_retries_per_task: int = field(default=5, metadata={"sticky": True})
+    max_worker_count: int = field(
+        default=-1, metadata={"sticky": True}
+    )  # -1 indicates unlimited max worker count
 
     # Render settings - some settings that have a False value aren't currently exposed in the UI
     #
-    AnimationClip: str = field(default="")
-    AnimationType: str = field(default="Clip")
-    DLSSQuality: str = field(default="Off")
-    DPI: int = field(default=72)
-    EndFrame: int = field(default=24)
-    FrameStep: int = field(default=1)
-    FramesPerTask: int = field(default=1)
-    GPURaytracing: bool = field(default=False)
-    ImageHeight: int = field(default=600)
-    ImageWidth: int = field(default=800)
-    IncludeAlphaChannel: bool = field(default=False)
-    JobType: str = field(default="Render")
-    NumXTiles: int = field(default=1)
-    NumYTiles: int = field(default=1)
-    OutputDir: str = field(default="")
-    OutputFileNamePrefix: str = field(default="output")
-    OutputFormat: str = field(default="PNG")
-    OverrideRenderPass: bool = field(default=False)
-    PremultiplyAlpha: bool = field(default=False)
-    RegionRendering: bool = field(default=False)
-    RenderAnimation: bool = field(default=True)
-    RenderQuality: str = field(default="Realistic High")
-    SSQuality: str = field(default="Off")
+    AnimationClip: str = field(default="", metadata={"sticky": True})
+    AnimationType: str = field(default="Clip", metadata={"sticky": True})
+    DLSSQuality: str = field(default="Off", metadata={"sticky": True})
+    DPI: int = field(default=72, metadata={"sticky": True})
+    EndFrame: int = field(default=24, metadata={"sticky": True})
+    FrameStep: int = field(default=1, metadata={"sticky": True})
+    FramesPerTask: int = field(default=1, metadata={"sticky": True})
+    GPURaytracing: bool = field(default=False, metadata={"sticky": True})
+    ImageHeight: int = field(default=600, metadata={"sticky": True})
+    ImageWidth: int = field(default=800, metadata={"sticky": True})
+    IncludeAlphaChannel: bool = field(default=False, metadata={"sticky": True})
+    JobType: str = field(default="Render", metadata={"sticky": True})
+    NumXTiles: int = field(default=1, metadata={"sticky": True})
+    NumYTiles: int = field(default=1, metadata={"sticky": True})
+    OutputDir: str = field(default="", metadata={"sticky": True})
+    OutputFileNamePrefix: str = field(default="output", metadata={"sticky": True})
+    OutputFormat: str = field(default="PNG", metadata={"sticky": True})
+    OverrideRenderPass: bool = field(default=False, metadata={"sticky": True})
+    PremultiplyAlpha: bool = field(default=False, metadata={"sticky": True})
+    RegionRendering: bool = field(default=False, metadata={"sticky": True})
+    RenderAnimation: bool = field(default=True, metadata={"sticky": True})
+    RenderQuality: str = field(default="Realistic High", metadata={"sticky": True})
+    SSQuality: str = field(default="Off", metadata={"sticky": True})
     SceneFile: str = field(default="")
-    SequenceName: str = field(default="")
-    StartFrame: int = field(default=0)
-    TonemapHDR: bool = field(default=False)
-    View: str = field(default="")
+    SequenceName: str = field(default="", metadata={"sticky": True})
+    StartFrame: int = field(default=0, metadata={"sticky": True})
+    TonemapHDR: bool = field(default=False, metadata={"sticky": True})
+    View: str = field(default="", metadata={"sticky": True})
+
+    def load_sticky_settings(self, scene_filename: str):
+        sticky_settings_filename = Path(scene_filename).with_suffix(
+            Constants.RENDER_SUBMITTER_SETTINGS_FILE_EXT
+        )
+        if sticky_settings_filename.exists() and sticky_settings_filename.is_file():
+            try:
+                with open(sticky_settings_filename, encoding="utf8") as fh:
+                    sticky_settings = json.load(fh)
+
+                if isinstance(sticky_settings, dict):
+                    _global_logger.info(f"Loaded sticky settings file: {sticky_settings_filename}")
+                    sticky_fields = {
+                        field.name: field
+                        for field in dataclasses.fields(self)
+                        if field.metadata.get("sticky")
+                    }
+                    for name, value in sticky_settings.items():
+                        # Only set fields that are defined in the dataclass
+                        if name in sticky_fields:
+                            setattr(self, name, value)
+                else:
+                    _global_logger.warning(
+                        f"Sticky settings file contains invalid data type: {type(sticky_settings)}"
+                    )
+
+            except (OSError, json.JSONDecodeError) as e:
+                # If something bad happened to the sticky settings file,
+                # just use the defaults instead of producing an error.
+                traceback.print_exc()
+                _global_logger.warning(
+                    f"Failed to load sticky settings file {sticky_settings_filename.absolute()}: {e}, reverting to default settings"
+                )
+
+    def save_sticky_settings(self, scene_filename: str):
+        sticky_settings_filename = Path(scene_filename).with_suffix(
+            Constants.RENDER_SUBMITTER_SETTINGS_FILE_EXT
+        )
+        sticky_settings_path = str(sticky_settings_filename.absolute())
+
+        try:
+            obj = {
+                field.name: getattr(self, field.name)
+                for field in dataclasses.fields(self)
+                if field.metadata.get("sticky")
+            }
+
+            _global_logger.info(f"Saving sticky settings to: {sticky_settings_path}")
+            with open(sticky_settings_filename, "w", encoding="utf8") as fh:
+                json.dump(obj, fh, indent=1)
+
+        except OSError as e:
+            _global_logger.warning(
+                f"Failed to save sticky settings file to {sticky_settings_path}: {e}", exc_info=True
+            )

--- a/src/deadline/vred_submitter/ui/components/scene_settings_populator.py
+++ b/src/deadline/vred_submitter/ui/components/scene_settings_populator.py
@@ -101,11 +101,14 @@ class SceneSettingsPopulator:
         # See: SceneSettingsCallbacks.scene_file_changed_callback()
         #
         if SceneSettingsPopulator.persisted_ui_settings_states is None:
-            self._store_runtime_derived_settings(initial_settings)
+            # Initialize persisted settings storage
             SceneSettingsPopulator.persisted_ui_settings_states = DynamicKeyValueObject(
                 {str(key).lower(): "" for key in PersistedUISettingsNames}
             )
+            # Capture sticky settings from initial_settings before they get overwritten
             SceneSettingsPopulator._configure_ui_persisted_settings(initial_settings)
+            # Now get VRED scene values (this will overwrite initial_settings but we've already captured the sticky values)
+            self._store_runtime_derived_settings(initial_settings)
         self._populate_runtime_ui_options_values(initial_settings)
         # Persisted settings will take precedence (in UI elements) over initial settings/defaults
         self._restore_persisted_ui_settings_states()

--- a/test/integ/output_comparison.py
+++ b/test/integ/output_comparison.py
@@ -44,12 +44,15 @@ def assert_parameter_values_similar(
     with open(job_history_dir / Constants.PARAMETER_VALUES_FILENAME) as file_handle:
         actual = yaml.safe_load(file_handle)[Constants.PARAMETER_VALUES_FIELD]
         expected = expected_parameter_values[Constants.PARAMETER_VALUES_FIELD]
-        assert len(actual) == len(expected)
+        assert len(actual) == len(
+            expected
+        ), f"Parameter count mismatch: expected {len(expected)}, got {len(actual)}"
         for param in expected:
             name, value = param[Constants.NAME_FIELD], param[Constants.VALUE_FIELD]
-            assert value == extract_parameter_value(
-                {Constants.PARAMETER_VALUES_FIELD: actual}, name
-            )
+            actual_value = extract_parameter_value({Constants.PARAMETER_VALUES_FIELD: actual}, name)
+            assert (
+                value == actual_value
+            ), f"Parameter '{name}' mismatch: expected '{value}', got '{actual_value}'"
 
 
 def assert_asset_references_similar(

--- a/test/integ/sticky_settings_verification.py
+++ b/test/integ/sticky_settings_verification.py
@@ -1,0 +1,65 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import json
+import dataclasses
+from pathlib import Path
+from typing import Dict, Any
+from unittest.mock import MagicMock
+import sys
+
+
+def verify_sticky_settings_file(
+    sticky_settings_file: Path, parameter_overrides: Dict[str, Any]
+) -> None:
+    """
+    Verify the contents of the sticky settings file match expected values.
+
+    :param sticky_settings_file: Path to the sticky settings JSON file
+    :param parameter_overrides: Dictionary of parameters that were overridden in the test
+    :raise AssertionError: If sticky settings file contents don't match expectations
+    """
+    # Mock vred_logger before importing data_classes to avoid vrController import issues
+    sys.modules["deadline.vred_submitter.vred_logger"] = MagicMock()
+    from deadline.vred_submitter.data_classes import RenderSubmitterUISettings
+
+    # Load the sticky settings file
+    with open(sticky_settings_file, "r", encoding="utf8") as f:
+        sticky_data = json.load(f)
+
+    assert isinstance(
+        sticky_data, dict
+    ), f"Sticky settings should be a dictionary, got {type(sticky_data)}"
+
+    # Get all sticky-enabled fields from the data class
+    sticky_fields = {
+        field.name: field
+        for field in dataclasses.fields(RenderSubmitterUISettings)
+        if field.metadata.get("sticky")
+    }
+
+    # Verify that test parameters that should be sticky are present in the file
+    sticky_test_params = {k: v for k, v in parameter_overrides.items() if k in sticky_fields}
+
+    for param_name, expected_value in sticky_test_params.items():
+        assert (
+            param_name in sticky_data
+        ), f"Sticky parameter '{param_name}' should be saved to sticky settings file"
+        actual_value = sticky_data[param_name]
+
+        # Handle type conversions (JSON stores everything as basic types)
+        if isinstance(expected_value, str) and expected_value.lower() in ["true", "false"]:
+            # Convert string booleans to actual booleans for comparison
+            expected_bool = expected_value.lower() == "true"
+            assert (
+                actual_value == expected_bool
+            ), f"Sticky parameter '{param_name}': expected {expected_bool}, got {actual_value}"
+        else:
+            assert (
+                actual_value == expected_value
+            ), f"Sticky parameter '{param_name}': expected {expected_value}, got {actual_value}"
+
+    # Verify that only sticky-enabled fields are in the file (no non-sticky fields leaked in)
+    for param_name in sticky_data.keys():
+        assert (
+            param_name in sticky_fields
+        ), f"Non-sticky parameter '{param_name}' should not be saved to sticky settings file"

--- a/test/unit/test_data_classes.py
+++ b/test/unit/test_data_classes.py
@@ -1,34 +1,199 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 """Tests for data classes used in VRED submitter."""
+import json
+import os
+import tempfile
+from pathlib import Path
 import pytest
 
 from vred_submitter.data_classes import RenderSubmitterUISettings
 
 
-class TestRenderSubmitterUISettings:
-    """Test RenderSubmitterUISettings data class for render job configuration."""
+class TestRenderSubmitterUISettingsStickySettings:
+    """Test sticky settings functionality in RenderSubmitterUISettings."""
 
     @pytest.fixture
     def render_settings(self):
         return RenderSubmitterUISettings()
 
-    def test_default_values(self, render_settings):
-        # Test key default values
-        assert render_settings.submitter_name == "VRED"
-        assert render_settings.AnimationType == "Clip"
-        assert render_settings.JobType == "Render"
-        assert render_settings.RenderAnimation
-        assert render_settings.ImageWidth == 800
-        assert render_settings.ImageHeight == 600
-        assert render_settings.OutputFormat == "PNG"
+    @pytest.fixture
+    def sticky_settings_data(self):
+        """Comprehensive test data for ALL sticky setting fields."""
+        return {
+            # String fields
+            "description": "Test job description",
+            "name": "Test Job Name",
+            "AnimationClip": "TestClip",
+            "AnimationType": "Timeline",
+            "DLSSQuality": "Quality",
+            "JobType": "Animation",
+            "OutputDir": "/test/output/dir",
+            "OutputFileNamePrefix": "test_render",
+            "OutputFormat": "EXR",
+            "RenderQuality": "Realistic Ultra",
+            "SSQuality": "High",
+            "SequenceName": "TestSequence",
+            "View": "Camera01",
+            # Integer fields
+            "DPI": 150,
+            "EndFrame": 100,
+            "FrameStep": 2,
+            "FramesPerTask": 5,
+            "ImageHeight": 1080,
+            "ImageWidth": 1920,
+            "NumXTiles": 3,
+            "NumYTiles": 2,
+            "StartFrame": 10,
+            # Boolean fields
+            "GPURaytracing": True,
+            "IncludeAlphaChannel": True,
+            "OverrideRenderPass": True,
+            "PremultiplyAlpha": True,
+            "RegionRendering": True,
+            "RenderAnimation": False,
+            "TonemapHDR": True,
+            # List fields
+            "input_filenames": ["test1.vpb", "test2.vpb"],
+            "input_directories": ["/test/input1", "/test/input2"],
+            "output_directories": ["/test/output1", "/test/output2"],
+        }
 
-    def test_field_assignment(self, render_settings):
-        # Test that fields can be assigned new values
-        render_settings.name = "Test Job"
-        render_settings.ImageWidth = 1920
-        render_settings.input_filenames.append("test.vpb")
+    def test_save_sticky_settings_handles_write_errors(self, render_settings):
+        """Test saving sticky settings handles file write errors gracefully."""
+        # Try to save to a directory that doesn't exist or is read-only
+        invalid_path = "/invalid/path/that/does/not/exist/scene.vpb"
 
-        assert render_settings.name == "Test Job"
-        assert render_settings.ImageWidth == 1920
-        assert "test.vpb" in render_settings.input_filenames
+        # Should not crash, but may log a warning
+        render_settings.save_sticky_settings(invalid_path)
+
+    def test_save_all_sticky_settings_fields(self, render_settings, sticky_settings_data):
+        """Test that ALL sticky settings fields are properly saved to JSON file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".vpb", delete=False) as scene_file:
+            scene_filename = scene_file.name
+
+        try:
+            # Set ALL sticky field values from test data
+            for field_name, value in sticky_settings_data.items():
+                setattr(render_settings, field_name, value)
+
+            # Save sticky settings
+            render_settings.save_sticky_settings(scene_filename)
+
+            # Verify file was created
+            sticky_filename = Path(scene_filename).with_suffix(".deadline_render_settings.json")
+            assert sticky_filename.exists()
+
+            # Load and verify file contents
+            with open(sticky_filename, "r") as f:
+                saved_data = json.load(f)
+
+            # Verify ALL string fields are saved
+            assert saved_data["description"] == "Test job description"
+            assert saved_data["name"] == "Test Job Name"
+            assert saved_data["AnimationClip"] == "TestClip"
+            assert saved_data["AnimationType"] == "Timeline"
+            assert saved_data["DLSSQuality"] == "Quality"
+            assert saved_data["JobType"] == "Animation"
+            assert saved_data["OutputDir"] == "/test/output/dir"
+            assert saved_data["OutputFileNamePrefix"] == "test_render"
+            assert saved_data["OutputFormat"] == "EXR"
+            assert saved_data["RenderQuality"] == "Realistic Ultra"
+            assert saved_data["SSQuality"] == "High"
+            assert saved_data["SequenceName"] == "TestSequence"
+            assert saved_data["View"] == "Camera01"
+
+            # Verify ALL integer fields are saved
+            assert saved_data["DPI"] == 150
+            assert saved_data["EndFrame"] == 100
+            assert saved_data["FrameStep"] == 2
+            assert saved_data["FramesPerTask"] == 5
+            assert saved_data["ImageHeight"] == 1080
+            assert saved_data["ImageWidth"] == 1920
+            assert saved_data["NumXTiles"] == 3
+            assert saved_data["NumYTiles"] == 2
+            assert saved_data["StartFrame"] == 10
+
+            # Verify ALL boolean fields are saved
+            assert saved_data["GPURaytracing"] is True
+            assert saved_data["IncludeAlphaChannel"] is True
+            assert saved_data["OverrideRenderPass"] is True
+            assert saved_data["PremultiplyAlpha"] is True
+            assert saved_data["RegionRendering"] is True
+            assert saved_data["RenderAnimation"] is False
+            assert saved_data["TonemapHDR"] is True
+
+            # Verify ALL list fields are saved
+            assert saved_data["input_filenames"] == ["test1.vpb", "test2.vpb"]
+            assert saved_data["input_directories"] == ["/test/input1", "/test/input2"]
+            assert saved_data["output_directories"] == ["/test/output1", "/test/output2"]
+
+            # Verify the correct number of fields are saved (should be exactly the sticky fields)
+            import dataclasses
+
+            sticky_field_count = len(
+                [
+                    field.name
+                    for field in dataclasses.fields(render_settings)
+                    if field.metadata.get("sticky")
+                ]
+            )
+            assert len(saved_data) == sticky_field_count
+
+        finally:
+            sticky_filename = Path(scene_filename).with_suffix(".deadline_render_settings.json")
+            if sticky_filename.exists():
+                os.remove(sticky_filename)
+
+    def test_sticky_settings_roundtrip(self, render_settings, sticky_settings_data):
+        """Test that ALL settings can be saved and loaded correctly (complete roundtrip test)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".vpb", delete=False) as scene_file:
+            scene_filename = scene_file.name
+
+        try:
+            # Set ALL values from test data
+            for field_name, value in sticky_settings_data.items():
+                setattr(render_settings, field_name, value)
+
+            # Save sticky settings
+            render_settings.save_sticky_settings(scene_filename)
+
+            # Create new instance and load
+            new_settings = RenderSubmitterUISettings()
+            new_settings.load_sticky_settings(scene_filename)
+
+            # Verify ALL values match exactly
+            for field_name, expected_value in sticky_settings_data.items():
+                actual_value = getattr(new_settings, field_name)
+                assert (
+                    actual_value == expected_value
+                ), f"Field {field_name}: expected {expected_value}, got {actual_value}"
+
+        finally:
+            sticky_filename = Path(scene_filename).with_suffix(".deadline_render_settings.json")
+            if sticky_filename.exists():
+                os.remove(sticky_filename)
+
+    def test_load_sticky_settings_invalid_data_type(self, render_settings):
+        """Test loading sticky settings when file contains non-dict data."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".vpb", delete=False) as scene_file:
+            scene_filename = scene_file.name
+
+        sticky_filename = None
+        try:
+            # Create file with array instead of object
+            sticky_filename = Path(scene_filename).with_suffix(".deadline_render_settings.json")
+            with open(sticky_filename, "w") as f:
+                json.dump(["not", "a", "dictionary"], f)
+
+            original_width = render_settings.ImageWidth
+
+            # Should not crash and should log warning
+            render_settings.load_sticky_settings(scene_filename)
+
+            # Values should remain unchanged
+            assert render_settings.ImageWidth == original_width
+
+        finally:
+            if sticky_filename and sticky_filename.exists():
+                os.remove(sticky_filename)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Other Deadline Cloud integrations such as Cinema4D have added "sticky" settings, which persist some render settings in the Deadline submitter for specific scenes. We have an issue requesting we add this to the VRED integration in https://github.com/aws-deadline/deadline-cloud-for-vred/issues/58

### What was the solution? (How)
Add the sticky settings! This adds a JSON file in the same directory of the scene file being submitted. It follows the same convention as the Cinema4D repository, `<SceneName>.deadline_render_settings.json`. If the file can't save or be loaded, it won't interfere with submission, it's simply a convenience feature.

### What is the impact of this change?
This should make the user experience a little nicer for repeat submissions of the same scene file.

### How was this change tested?
- Wrote new tests and ran unit and integration tests on a Windows machine
- Made a really long path for a scene file (over 250 characters) and confirmed it could save and load the sticky settings and submit a job without issue

#### Please run the integration tests and paste the results below
```
test/integ/test_vred_submitter.py::TestVREDSubmitter::test_submitter_dialog_basic_settings
[gw0] [ 33%] PASSED test/integ/test_vred_submitter.py::TestVREDSubmitter::test_submitter_dialog_basic_settings
test/integ/test_vred_submitter.py::TestVREDSubmitter::test_submitter_dialog_tiling_settings
[gw0] [ 66%] PASSED test/integ/test_vred_submitter.py::TestVREDSubmitter::test_submitter_dialog_tiling_settings
test/integ/test_vred_submitter.py::TestVREDSubmitter::test_submitter_dialog_bundle_comparison
[gw0] [100%] PASSED test/integ/test_vred_submitter.py::TestVREDSubmitter::test_submitter_dialog_bundle_comparison
```


#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
N/A

### Was this change documented?
Yes

### Is this a breaking change?
No, but this does add a new feature.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
