### PR TITLE
fix: prevent multiple tasks when region rendering is not enabled

### DIFF
--- a/src/deadline/vred_submitter/constants.py
+++ b/src/deadline/vred_submitter/constants.py
@@ -19,31 +19,45 @@ class ConstantsMeta(type):
 
 
 class Constants(metaclass=ConstantsMeta):
-    """Constants class for backend submitter component"""
+    """
+    Constants class for backend submitter component.
 
-    ANIMATION_SETTINGS_DIALOG_NAME: Final[str] = "Animation Settings"
+    Common naming patterns:
+
+    OpenJobDescription (Job Template) Related:
+    - _JOB_PARAM: Job-level parameters defined in parameterDefinitions in Job Template
+    - _FIELD: Structural field names in Job Template
+    - _STEP: Step names used to identify Steps within a Job Template
+
+    Others:
+    - _KEY: Keys used in telemetry, metadata, or configuration dictionaries
+    - _ENV_VAR: Environment variable names
+    - _FILENAME: File names and extensions
+
+    Error Messages:
+    - ERROR_: User-facing error messages
+    """
+
+    ANIMATION_SETTINGS_DIALOG: Final[str] = "Animation Settings"
     ASSET_REFERENCES_FILENAME: Final[str] = "asset_references.yaml"
     BASE_TEN: Final[int] = 10
-    CONDA_CHANNELS_FIELD: Final[str] = "CondaChannels"
+    CONDA_CHANNELS_JOB_PARAM: Final[str] = "CondaChannels"
     CONDA_CHANNELS_OVERRIDE_ENV_VAR: Final[str] = "CONDA_CHANNELS"
-    CONDA_PACKAGES_FIELD: Final[str] = "CondaPackages"
+    CONDA_PACKAGES_JOB_PARAM: Final[str] = "CondaPackages"
     CONDA_PACKAGES_OVERRIDE_ENV_VAR: Final[str] = "CONDA_PACKAGES"
-    CUSTOM_SPEED_FIELD_NAME: Final[str] = "_customSpeed"
-    DEADLINE_CLOUD_FOR_VRED_PACKAGE_PREFIX: Final[str] = "deadline_cloud_for_vred"
-    DEADLINE_CLOUD_FOR_VRED_SUBMITTER_VERSION_FIELD: Final[str] = (
+    CUSTOM_SPEED_NAME: Final[str] = "_customSpeed"
+    DEADLINE_CLOUD_FOR_VRED_SUBMITTER_VERSION_KEY: Final[str] = (
         "deadline-cloud-for-vred-submitter-version"
     )
-    DEADLINE_CLOUD_MENU_NAME: Final[str] = "Deadline Cloud"
+    DEADLINE_CLOUD_MENU: Final[str] = "Deadline Cloud"
     DEADLINE_HOME: Final[str] = str(Path.home() / ".deadline")
-    DEFAULT_FIELD: Final[str] = "default"
     DEFAULT_JOB_TEMPLATE_FILENAME: Final[str] = "default_vred_job_template.yaml"
     DEFAULT_SCENE_FILE_FPS_COUNT: Final[float] = 24.0
     DESCRIPTION_FIELD: Final[str] = "description"
-    ENVIRONMENT_FIELD: Final[str] = "environment"
     ERROR_ANIMATION_SETTINGS_DIALOG_NOT_FOUND: Final[str] = "Animation settings dialog not found"
-    ERROR_FILE_NOT_FOUND_ISSUE: Final[str] = "File not found"
-    ERROR_FILE_PERMISSIONS_ISSUE: Final[str] = "Permission denied accessing file"
-    ERROR_FILE_WRITE_ISSUE: Final[str] = "Permission denied writing file"
+    ERROR_FILE_NOT_FOUND: Final[str] = "File not found"
+    ERROR_FILE_ACCESS_PERMISSION_DENIED: Final[str] = "Permission denied accessing file"
+    ERROR_FILE_WRITE_PERMISSION_DENIED: Final[str] = "Permission denied writing file"
     ERROR_FRAME_RANGE_FORMAT_INVALID: Final[str] = (
         "Invalid frame range format. Please revise and retry."
     )
@@ -64,7 +78,7 @@ class Constants(metaclass=ConstantsMeta):
     ERROR_SPEED_SETTINGS_WIDGET_NOT_FOUND: Final[str] = "Speed widget not found"
     ERROR_TIMELINE_ACTION_NOT_FOUND: Final[str] = "Timeline action not found"
     ERROR_TIMELINE_TOOLBAR_NOT_FOUND: Final[str] = "Timeline toolbar not found"
-    ERROR_YAML_GENERAL_ERROR: Final[str] = "Unexpected error reading YAML file"
+    ERROR_YAML_UNEXPECTED_ERROR: Final[str] = "Unexpected error reading YAML file"
     ERROR_YAML_INVALID_FORMAT: Final[str] = "Invalid YAML format in"
     ERROR_YAML_OBJECT_NOT_FOUND: Final[str] = "YAML file must contain a dictionary/object, got"
     ERROR_YAML_NOT_FOUND: Final[str] = "YAML file not found"
@@ -77,6 +91,8 @@ class Constants(metaclass=ConstantsMeta):
     NAME_FIELD: Final[str] = "name"
     NAN: Final[str] = "NaN"
     NEGATIVE_INFINITY: Final[str] = "-inf"
+    NUM_X_TILES_JOB_PARAM: Final[str] = "NumXTiles"
+    NUM_Y_TILES_JOB_PARAM: Final[str] = "NumYTiles"
     PARAMETER_DEFINITIONS_FIELD: Final[str] = "parameterDefinitions"
     PARAMETER_VALUES_FIELD: Final[str] = "parameterValues"
     PARAMETER_VALUES_FILENAME: Final[str] = "parameter_values.yaml"
@@ -88,19 +104,18 @@ class Constants(metaclass=ConstantsMeta):
         "The scene file has unsaved local changes that will not be included in the job "
         "submission.\n\nDo you want to save the scene file before submitting?"
     )
-    SUBMIT_TO_DEADLINE_CLOUD_ACTION_NAME: Final[str] = "Submit To Deadline Cloud"
+    SUBMIT_TO_DEADLINE_CLOUD_ACTION: Final[str] = "Submit To Deadline Cloud"
     STEPS_FIELD: Final[str] = "steps"
     TEMPLATE_FILENAME: Final[str] = "template.yaml"
-    TILE_ASSEMBLY_STEP_NAME: Final[str] = "Tile Assembly"
-    TIMELINE_ACTION_NAME: Final[str] = "Timeline"
+    TILE_ASSEMBLY_STEP: Final[str] = "Tile Assembly"
+    TIMELINE_ACTION: Final[str] = "Timeline"
     TIMELINE_ANIMATION_PREFS_BUTTON_NAME: Final[str] = "_prefs"
     TIMELINE_TOOLBAR_NAME: Final[str] = "Timeline_Toolbar"
     UTF8_FLAG: Final[str] = "utf-8"
     VALUE_FIELD: Final[str] = "value"
     VRED_CORE_CONDA_PACKAGE_PREFIX: Final[str] = "vredcore"
-    VRED_PRO_CONDA_PACKAGE_PREFIX: Final[str] = "vred"
     VRED_RENDER_SCRIPT_FILENAME: Final[str] = "VRED_RenderScript_DeadlineCloud.py"
-    VRED_VERSION_FIELD: Final[str] = "vred-version"
+    VRED_VERSION_KEY: Final[str] = "vred-version"
     WRITE_FLAG: Final[str] = "w"
 
     def __new__(cls):

--- a/src/deadline/vred_submitter/ui/components/constants.py
+++ b/src/deadline/vred_submitter/ui/components/constants.py
@@ -46,7 +46,7 @@ class ConstantsMeta(type):
 class Constants(metaclass=ConstantsMeta):
     """Constants class for UI settings."""
 
-    ANIMATION_SETTINGS_DIALOG_NAME: Final[str] = "Animation Settings"
+    ANIMATION_SETTINGS_DIALOG: Final[str] = "Animation Settings"
     ANIMATION_CLIP_LABEL: Final[str] = "Animation Clip"
     ANIMATION_CLIP_LABEL_DESCRIPTION: Final[str] = "The name of the animation clip to render."
     ANIMATION_TYPE_LABEL: Final[str] = "Animation Type"
@@ -66,7 +66,7 @@ class Constants(metaclass=ConstantsMeta):
     def COMBO_BOX_PADDING(cls) -> int:
         return int(24 * _global_dpi_scale.factor)
 
-    CUSTOM_SPEED_FIELD_NAME: Final[str] = "_customSpeed"
+    CUSTOM_SPEED_NAME: Final[str] = "_customSpeed"
     DEFAULT_IMAGE_SIZE_PRESET: Final[str] = "SVGA (800 x 600)"
     DEFAULT_SCENE_FILE_FPS_COUNT: Final[float] = 24.0
     DEFAULT_DPI_RESOLUTION: Final[int] = 72
@@ -291,7 +291,7 @@ class Constants(metaclass=ConstantsMeta):
     TILES_IN_Y_LABEL_DESCRIPTION: Final[str] = (
         "The number of tiles to vertically divide the specified  image size."
     )
-    TIMELINE_ACTION_NAME: Final[str] = "Timeline"
+    TIMELINE_ACTION: Final[str] = "Timeline"
     TIMELINE_ANIMATION_PREFS_BUTTON_NAME: Final[str] = "_prefs"
     TIMELINE_TOOLBAR_NAME: Final[str] = "Timeline_Toolbar"
     USE_CLIP_RANGE_LABEL: Final[str] = "Use Clip Range"

--- a/src/deadline/vred_submitter/utils.py
+++ b/src/deadline/vred_submitter/utils.py
@@ -155,13 +155,17 @@ def get_yaml_contents(file_path: str) -> Dict[str, Any]:
             f"{Constants.ERROR_YAML_INVALID_FORMAT} {file_path}: {str(yaml_err)}"
         ) from yaml_err
     except FileNotFoundError as error:
-        raise FileNotFoundError(f"{Constants.ERROR_FILE_NOT_FOUND_ISSUE} {file_path}") from error
+        raise FileNotFoundError(f"{Constants.ERROR_FILE_NOT_FOUND} {file_path}") from error
     except TypeError:
         raise
     except PermissionError as error:
-        raise PermissionError(f"{Constants.ERROR_FILE_PERMISSIONS_ISSUE} {file_path}") from error
+        raise PermissionError(
+            f"{Constants.ERROR_FILE_ACCESS_PERMISSION_DENIED} {file_path}"
+        ) from error
     except Exception as exc:
-        raise RuntimeError(f"{Constants.ERROR_YAML_GENERAL_ERROR} {file_path}: {str(exc)}") from exc
+        raise RuntimeError(
+            f"{Constants.ERROR_YAML_UNEXPECTED_ERROR} {file_path}: {str(exc)}"
+        ) from exc
 
 
 def is_number(string: str) -> bool:

--- a/src/deadline/vred_submitter/vred_submitter.py
+++ b/src/deadline/vred_submitter/vred_submitter.py
@@ -82,11 +82,10 @@ class VREDSubmitter:
             job_template[Constants.DESCRIPTION_FIELD] = settings.description
         if not settings.RegionRendering:
             # For regular render jobs (not relying on region rendering), exclude tile assembly step from job template
-            #
             job_template[Constants.STEPS_FIELD] = [
                 step
                 for step in job_template[Constants.STEPS_FIELD]
-                if step.get(Constants.NAME_FIELD) != Constants.TILE_ASSEMBLY_STEP_NAME
+                if step.get(Constants.NAME_FIELD) != Constants.TILE_ASSEMBLY_STEP
             ]
         return job_template
 
@@ -113,22 +112,32 @@ class VREDSubmitter:
         }
 
         # Note: represent the bool-typed settings values as string-equivalents of "true" or "false" value for OpenJD
-        parameter_values = [
-            {
-                Constants.NAME_FIELD: field.name,  # type: ignore
-                Constants.VALUE_FIELD: (  # type: ignore
-                    str(getattr(settings, field.name)).lower()
-                    if isinstance(getattr(settings, field.name), bool)
-                    else getattr(settings, field.name)
-                ),
-            }
-            for field in fields(type(settings))
-            if field.name not in shared_parameters
-        ]
+        parameter_values = []
+        for field in fields(type(settings)):
+            if field.name not in shared_parameters:
+                field_value = getattr(settings, field.name)
+
+                # Override NumXTiles and NumYTiles to 1 when region rendering is disabled
+                # to prevent creating multiple tasks (rendering the same output image) when tiling is not intended
+                if not settings.RegionRendering and field.name in [
+                    Constants.NUM_X_TILES_JOB_PARAM,
+                    Constants.NUM_Y_TILES_JOB_PARAM,
+                ]:
+                    field_value = 1
+
+                parameter_values.append(
+                    {
+                        Constants.NAME_FIELD: field.name,  # type: ignore
+                        Constants.VALUE_FIELD: (  # type: ignore
+                            str(field_value).lower()
+                            if isinstance(field_value, bool)
+                            else field_value
+                        ),
+                    }
+                )
 
         # Check for any overlap between the job parameters we've defined and the queue parameters. This is an error,
         # as we weren't synchronizing the values between the two different tabs where they came from.
-        #
         parameter_names = {param[Constants.NAME_FIELD] for param in parameter_values}  # type: ignore
         queue_parameter_names = {param[Constants.NAME_FIELD] for param in queue_parameters}  # type: ignore
         parameter_overlap = parameter_names.intersection(queue_parameter_names)
@@ -155,8 +164,8 @@ class VREDSubmitter:
         # Initialize the telemetry client, opt-out is respected
         get_deadline_cloud_library_telemetry_client().update_common_details(
             {
-                Constants.DEADLINE_CLOUD_FOR_VRED_SUBMITTER_VERSION_FIELD: version,
-                Constants.VRED_VERSION_FIELD: get_major_version(),
+                Constants.DEADLINE_CLOUD_FOR_VRED_SUBMITTER_VERSION_KEY: version,
+                Constants.VRED_VERSION_KEY: get_major_version(),
             }
         )
         submitter_dialog = self._create_submitter_dialog(render_settings, attachments)
@@ -226,9 +235,9 @@ class VREDSubmitter:
         )
         conda_packages = os.getenv(Constants.CONDA_PACKAGES_OVERRIDE_ENV_VAR) or conda_packages
         conda_channels = os.getenv(Constants.CONDA_CHANNELS_OVERRIDE_ENV_VAR)
-        shared_parameter_values = {Constants.CONDA_PACKAGES_FIELD: conda_packages}
+        shared_parameter_values = {Constants.CONDA_PACKAGES_JOB_PARAM: conda_packages}
         if conda_channels:
-            shared_parameter_values[Constants.CONDA_CHANNELS_FIELD] = conda_channels
+            shared_parameter_values[Constants.CONDA_CHANNELS_JOB_PARAM] = conda_channels
         # Need to apply these settings prior in order to ensure that Qt Controls are sized as expected!
         _global_dpi_scale.factor = get_dpi_scale_factor()
         submitter_dialog = SubmitJobToDeadlineDialog(
@@ -326,7 +335,6 @@ class VREDSubmitter:
         """
         # Keep the job bundle render script contained in its own directory to avoid accumulating recursive references.
         # Ensure no spaces in the job bundle render script path (spaces can interfere with module path searches).
-        #
         settings.JobScriptDir = Constants.JOB_BUNDLE_SCRIPTS_FOLDER_PATH
         try:
             if not os.path.exists(settings.JobScriptDir):
@@ -336,7 +344,9 @@ class VREDSubmitter:
                 settings.JobScriptDir,
             )
         except Exception as exc:
-            raise IOError(f"{Constants.ERROR_FILE_WRITE_ISSUE}: {settings.JobScriptDir} {exc}")
+            raise IOError(
+                f"{Constants.ERROR_FILE_WRITE_PERMISSION_DENIED}: {settings.JobScriptDir} {exc}"
+            )
         job_template = self._get_job_template(
             default_job_template=self.default_job_template, settings=settings
         )

--- a/src/deadline/vred_submitter/vred_submitter_wrapper.py
+++ b/src/deadline/vred_submitter/vred_submitter_wrapper.py
@@ -43,21 +43,19 @@ def add_deadline_cloud_menu() -> None:
     vred_menu_bar = get_main_window().menuBar()
     deadline_cloud_menu = None
     for child in vred_menu_bar.findChildren(QMenu):
-        if child.title() == Constants.DEADLINE_CLOUD_MENU_NAME:
+        if child.title() == Constants.DEADLINE_CLOUD_MENU:
             deadline_cloud_menu = child
             break
     if deadline_cloud_menu is None:
-        deadline_cloud_menu = QMenu(Constants.DEADLINE_CLOUD_MENU_NAME, vred_menu_bar)
-        deadline_cloud_menu.setObjectName(Constants.DEADLINE_CLOUD_MENU_NAME)
+        deadline_cloud_menu = QMenu(Constants.DEADLINE_CLOUD_MENU, vred_menu_bar)
+        deadline_cloud_menu.setObjectName(Constants.DEADLINE_CLOUD_MENU)
         vred_menu_bar.addMenu(deadline_cloud_menu)
     submit_action_exists = any(
-        action.text() == Constants.SUBMIT_TO_DEADLINE_CLOUD_ACTION_NAME
+        action.text() == Constants.SUBMIT_TO_DEADLINE_CLOUD_ACTION
         for action in deadline_cloud_menu.actions()
     )
     if not submit_action_exists:
-        deadline_action = QAction(
-            Constants.SUBMIT_TO_DEADLINE_CLOUD_ACTION_NAME, deadline_cloud_menu
-        )
+        deadline_action = QAction(Constants.SUBMIT_TO_DEADLINE_CLOUD_ACTION, deadline_cloud_menu)
         deadline_action.triggered.connect(submit_to_deadline_cloud)
         deadline_cloud_menu.addAction(deadline_action)
 

--- a/src/deadline/vred_submitter/vred_utils.py
+++ b/src/deadline/vred_submitter/vred_utils.py
@@ -299,7 +299,7 @@ def get_scene_fps() -> float:
             (
                 obj
                 for obj in vrMainWindow.findChildren(QAction)
-                if obj.text() == Constants.TIMELINE_ACTION_NAME
+                if obj.text() == Constants.TIMELINE_ACTION
             ),
             None,
         )
@@ -339,16 +339,14 @@ def get_scene_fps() -> float:
 
         # In the animation settings dialog, get the FPS value from settings dialog
         animation_settings_widget = vrMainWindow.findChild(
-            QDialog, Constants.ANIMATION_SETTINGS_DIALOG_NAME
+            QDialog, Constants.ANIMATION_SETTINGS_DIALOG
         )
         if not animation_settings_widget:
             raise LookupError(Constants.ERROR_ANIMATION_SETTINGS_DIALOG_NOT_FOUND)
 
         animation_settings_widget.hide()
 
-        speed_widget = animation_settings_widget.findChild(
-            QObject, Constants.CUSTOM_SPEED_FIELD_NAME
-        )
+        speed_widget = animation_settings_widget.findChild(QObject, Constants.CUSTOM_SPEED_NAME)
         if not speed_widget:
             raise LookupError(Constants.ERROR_SPEED_SETTINGS_WIDGET_NOT_FOUND)
         return float(speed_widget.text().split()[0])

--- a/test/unit/test_vred_submitter.py
+++ b/test/unit/test_vred_submitter.py
@@ -137,6 +137,50 @@ class TestVREDSubmitter:
         with pytest.raises(Exception):  # DeadlineOperationError
             submitter._get_parameter_values(settings, queue_parameters)
 
+    def test_get_parameter_values_when_region_rendering_disabled(self, submitter):
+        # Test that NumXTiles and NumYTiles are overridden to 1 when RegionRendering is False.
+
+        # Create settings with RegionRendering disabled but the number of tiles > 1
+        settings = RenderSubmitterUISettings()
+        settings.RegionRendering = False
+        settings.NumXTiles = 3
+        settings.NumYTiles = 2
+        queue_parameters: list[dict] = []
+
+        # Get parameter values
+        parameter_values = submitter._get_parameter_values(settings, queue_parameters)
+
+        # Find NumXTiles and NumYTiles parameters
+        num_x_tiles_param = next((p for p in parameter_values if p["name"] == "NumXTiles"), None)
+        num_y_tiles_param = next((p for p in parameter_values if p["name"] == "NumYTiles"), None)
+
+        # Verify they are overridden to 1
+        assert num_x_tiles_param is not None, "NumXTiles parameter not found"
+        assert num_y_tiles_param is not None, "NumYTiles parameter not found"
+        assert (
+            num_x_tiles_param["value"] == 1
+        ), f"Expected NumXTiles=1, got {num_x_tiles_param['value']}"
+        assert (
+            num_y_tiles_param["value"] == 1
+        ), f"Expected NumYTiles=1, got {num_y_tiles_param['value']}"
+
+        # Test with RegionRendering enabled
+        settings.RegionRendering = True
+        parameter_values = submitter._get_parameter_values(settings, queue_parameters)
+
+        num_x_tiles_param = next((p for p in parameter_values if p["name"] == "NumXTiles"), None)
+        num_y_tiles_param = next((p for p in parameter_values if p["name"] == "NumYTiles"), None)
+
+        # Verify original values are preserved
+        assert num_x_tiles_param is not None, "NumXTiles parameter not found"
+        assert num_y_tiles_param is not None, "NumYTiles parameter not found"
+        assert (
+            num_x_tiles_param["value"] == 3
+        ), f"Expected NumXTiles=3, got {num_x_tiles_param['value']}"
+        assert (
+            num_y_tiles_param["value"] == 2
+        ), f"Expected NumYTiles=2, got {num_y_tiles_param['value']}"
+
     @patch("vred_submitter.vred_submitter.center_widget")
     @patch("vred_submitter.vred_submitter.get_deadline_cloud_library_telemetry_client")
     def test_show_submitter(self, mock_telemetry_client, mock_center_widget, submitter):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When users turn off the "Enable Region Rendering" option in the VRED submitter but leave "Tiles in X" or "Tiles in Y" values greater than 1, the job submission would still create multiple Tasks based on the tile count. 

For example, with `RegionRendering` = false, `NumXTiles` = 3, and `NumYTiles` = 2, the submitter would incorrectly generate 6 tasks (rendering the same output image) instead of the expected single task.

This behavior can be confusing to users and wasteful of compute resources, as all tasks would perform identical work (rendering the full image).

### What was the solution? (How)
Override `NumXTiles` and `NumYTiles` to 1 when `RegionRendering` is false to ensure only single task is created regardless of user-specified tile values in the UI.

### What is the impact of this change?
Users will no longer see unexpected multiple tasks when region rendering is turned-off.

### How was this change tested?
- Added a new unit test to verify the parameter override works correctly for RegionRendering is not enabled.
- Made sure that all unit tests are passed on both MacOS and Windows environment
- Made sure that all integration tests are passed on Windows

### Was this change documented?

*delete text starting here*
- Added a couple lines of docstrings
- No need to update README.md, DEVELOPMENT.md, or other documents in the repository's docs/ directory

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
