### PR TITLE
chore: Update changelog to include changes from the skipped 0.1.3 in …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 
 
-
-## 0.1.3 (2025-09-19)
-
-
-
 ### Bug Fixes
 * Add license error detection in VRED job rendering (#76) ([`7d78b93`](https://github.com/aws-deadline/deadline-cloud-for-vred/commit/7d78b933087765d21e6af14e9ff967b94e51c3cb))
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We skipped the 0.1.3 release due to a build issue, resulting in a 0.1.4 with an empty changelog

### What was the solution? (How)
Updated the changelog so the changes from the skipped 0.1.3 are in 0.1.4.

### What is the impact of this change?
It will avoid confusion in the changelog.

### How was this change tested?
N/A, since it's just a changelog issue.

#### Please run the integration tests and paste the results below
N/A

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
N/A

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
