### PR TITLE
ci: add missing permissions for GitHub actions

### DIFF
--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -13,6 +13,10 @@ on:
         - minor
         - major
 
+permissions:
+  contents: write
+  pull-requests: write
+
 concurrency:
   group: release
 

--- a/.github/workflows/responded.yml
+++ b/.github/workflows/responded.yml
@@ -3,6 +3,10 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   check-for-response:
     uses: aws-deadline/.github/.github/workflows/reusable_responded.yml@mainline

--- a/.github/workflows/stale_prs_and_issues.yml
+++ b/.github/workflows/stale_prs_and_issues.yml
@@ -4,6 +4,10 @@ on:
     # Run every hour on the hour
     - cron: '0 * * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   check-for-stales:
     uses: aws-deadline/.github/.github/workflows/reusable_stale_prs_and_issues.yml@mainline


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Some of our GitHub Actions such as `stale_prs_and_issues` are failing with permission errors such as:

```
The workflow is requesting 'issues: write, pull-requests: write', but is only allowed 'issues: none, pull-requests: none'.
```

### What was the solution? (How)

We copied the missing permissions from the Workflow templates in https://github.com/aws-deadline/.github/tree/mainline/.github/workflows into workflows in this project.

### What is the impact of this change?

This should fix the permission errors that are causing our GitHub Actions to fail.

### How was this change tested?

Not tested.

#### Please run the integration tests and paste the results below

I only changed permissions in the GitHub Workflow files which should have no impact on the integration itself.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

n/a

### Was this change documented?

n/a

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
