### PR TITLE
ci: add missing permissions for GitHub actions

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -28,6 +28,10 @@ on:
         options:
         - mainline
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   BuildInstaller:
     if: (github.repository == 'aws-deadline/deadline-cloud-for-vred')

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 8 * * MON'
 
+permissions:
+  security-events: write
+
 jobs:
   Analysis:
     name: Analysis

--- a/.github/workflows/stale_prs_and_issues.yml
+++ b/.github/workflows/stale_prs_and_issues.yml
@@ -5,6 +5,7 @@ on:
     - cron: '0 * * * *'
 
 permissions:
+  contents: read
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Some of our GitHub Actions such as `stale_prs_and_issues` are still failing with permission errors such as:

```
The workflow is requesting 'contents: read', but is only allowed 'contents: none'.
```

### What was the solution? (How)

Copy additional permissions from the Workflow templates in https://github.com/aws-deadline/.github/tree/mainline/.github/workflows into workflows in this project.

### What is the impact of this change?

This should fix the permission errors that are causing our GitHub Actions to fail.

### How was this change tested?

Not tested.

#### Please run the integration tests and paste the results below

I only changed permissions in the GitHub Workflow files which should have no impact on the integration itself.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

n/a

### Was this change documented?

n/a

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
