### PR TITLE
docs: kiro powers for setup, dev, design

### DIFF
--- a/.kiro/powers/vred-design-power/POWER.md
+++ b/.kiro/powers/vred-design-power/POWER.md
@@ -1,0 +1,70 @@
+---
+name: "vred-design-power"
+displayName: "VRED Design Power"
+description: "Structured design assistant for VRED features in Deadline Cloud. Creates comprehensive design documents covering data structures, UX changes, job templates, and render script modifications."
+keywords: ["vred", "design", "submitter", "render", "tiling"]
+author: "AWS Deadline Cloud Team"
+---
+
+# VRED Design Power
+
+## Overview
+
+> **Terminal Output Pattern:** When running PowerShell commands that produce output you need to verify, always pipe to a temp file (`<command> | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8`), read it with `readFile`, then delete it. This avoids terminal output parsing issues.
+
+A structured design assistant for creating comprehensive feature designs for VRED integration with AWS Deadline Cloud. This power helps create well-structured design documents following a consistent format that covers all aspects of implementation.
+
+## Code Snippet Style Guide
+
+When including code in design documents, use **concise inline snippets** in the main sections and put **full implementations in an appendix**.
+
+### Inline Code Format
+
+Show only the relevant changes with context:
+
+```python
+def existing_function():
+    ...existing logic...
+    
+    # NEW: Add feature X support
+    if feature_x_enabled:
+        self._configure_feature_x(data)
+    
+    ...rest of function...
+```
+
+### Appendix Format
+
+Put complete implementations in a clearly marked appendix section:
+
+```markdown
+---
+
+## Appendix: Full Code Implementations
+
+<!-- REVIEW: New render script change -->
+
+### A.1 RenderScript.configure_feature (Full Implementation)
+
+\`\`\`python
+def configure_feature(self, data: dict) -> None:
+    """Full implementation here..."""
+    # Complete code
+\`\`\`
+```
+
+### Guidelines
+
+1. **Data structures are the exception**: Always show full definitions - they anchor the design
+2. **Other sections**: Show what changes and where, not full implementations
+3. **Use `...` or comments** to indicate existing/unchanged code
+4. **Flag new sections** with `<!-- REVIEW: description -->` comments in the appendix
+5. **Don't include review tags** in final generated code
+
+## Research Requirements
+
+Before finalizing any design, research VRED Python APIs and existing implementation patterns. Refer to **research-guide.md** for details.
+
+## External References
+
+Refer to **external-references.md** for GitHub links and documentation.

--- a/.kiro/powers/vred-design-power/steering/deadline-cloud-architecture.md
+++ b/.kiro/powers/vred-design-power/steering/deadline-cloud-architecture.md
@@ -1,0 +1,263 @@
+---
+inclusion: manual
+---
+
+# Deadline Cloud for VRED Architecture Guide
+
+This guide explains the architecture of the Deadline Cloud for VRED integration to help with design decisions.
+
+## High-Level Architecture
+
+```
++------------------------------------------------------------------+
+|                     VRED Pro (Artist Workstation)                |
+|  +------------------------------------------------------------+  |
+|  |                    Submitter Dialog                        |  |
+|  |  - Collects job settings from user                         |  |
+|  |  - Reads scene information via VRED Python API             |  |
+|  |  - Creates job bundle                                      |  |
+|  +------------------------------------------------------------+  |
++------------------------------------------------------------------+
+                              |
+                              | Job Bundle (YAML + assets)
+                              v
++------------------------------------------------------------------+
+|                      AWS Deadline Cloud                          |
+|  - Schedules jobs                                                |
+|  - Distributes tasks to workers                                  |
+|  - Manages job queues                                            |
++------------------------------------------------------------------+
+                              |
+                              | Task assignment
+                              v
++------------------------------------------------------------------+
+|                    Worker (Render Node)                          |
+|  +------------------------------------------------------------+  |
+|  |              VRED_RenderScript_DeadlineCloud.py            |  |
+|  |  - Launched by OpenJD inside VRED Core/Pro process         |  |
+|  |  - Reads job parameters from environment                   |  |
+|  |  - Configures render settings via VRED Python API          |  |
+|  |  - Executes rendering                                      |  |
+|  +------------------------------------------------------------+  |
++------------------------------------------------------------------+
+```
+
+## Key Difference from other DCCs
+
+VRED does NOT use the adaptor/client pattern. Instead:
+- The render script (`VRED_RenderScript_DeadlineCloud.py`) runs directly inside the VRED process
+- Bootstrap code injection is used to launch the render script
+- Parameters are passed via environment variables and job bundle YAML files
+
+## Component Details
+
+### 1. Submitter (`src/deadline/vred_submitter/`)
+
+The submitter runs inside VRED Pro on the artist's workstation.
+
+**Key Files:**
+- `vred_submitter.py` - Main VREDSubmitter class, orchestrates job submission
+- `vred_submitter_wrapper.py` - Wrapper for standalone submitter mode
+- `ui/components/` - Qt UI components for the submitter dialog
+- `data_classes.py` - RenderSubmitterUISettings dataclass
+- `scene.py` - Scene file information and utilities
+- `assets.py` - AssetIntrospector for detecting scene dependencies
+- `vred_utils.py` - VRED Python API interface utilities
+- `qt_utils.py` - Qt-specific utilities and helpers
+- `qt_components.py` - Reusable Qt components
+- `constants.py` - Shared constants
+- `utils.py` - General utilities
+- `default_vred_job_template.yaml` - Default job template
+
+**Responsibilities:**
+- Display job submission dialog
+- Collect user settings (render quality, dimensions, animation, tiling, etc.)
+- Analyze scene (viewpoints, animation clips, file references)
+- Create job bundle with template, parameters, and asset references
+- Submit to Deadline Cloud
+
+### 2. UI Layer Components
+
+#### SceneSettingsWidget
+- **Purpose**: Main Qt widget container for render configuration UI
+- **Key Functions**: `_build_ui()`, `update_settings()`, `eventFilter()`
+- **UI Sections**: General options, render options, sequencer options, tiling settings
+
+#### SceneSettingsCallbacks
+- **Purpose**: Handles all Qt signal/slot connections and UI event responses
+- **Key Functions**: `_register_all_qt_callbacks()`, `job_type_changed_callback()`, `image_size_preset_selection_changed_callback()`, `animation_clip_selection_changed_callback()`, `enable_region_rendering_changed_callback()`
+- **State Management**: Persists UI settings between dialog sessions
+
+#### SceneSettingsPopulator
+- **Purpose**: Manages UI value population and persistence between sessions
+- **Key Functions**: `_store_runtime_derived_settings()`, `_populate_runtime_ui_options_values()`, `_restore_persisted_ui_settings_states()`, `update_settings_callback()`
+
+### 3. Data and Utility Components
+
+#### RenderSubmitterUISettings
+- **Purpose**: Data class containing all render job parameters
+- **Categories**: Internal settings, render settings, output settings, animation settings, tiling settings, advanced settings
+- **Validation**: Field types match OpenJD parameter requirements
+
+#### AssetIntrospector
+- **Purpose**: Analyzes scene files to detect asset dependencies
+- **Asset Detection**: Combines scene file path with VRED file references
+
+#### Scene
+- **Purpose**: Provides scene file information and utilities
+- **Animation Subclass**: Handles frame range and animation queries
+
+### 4. Render Script (`VRED_RenderScript_DeadlineCloud.py`)
+
+The render script runs on the worker inside the VRED process.
+
+**Responsibilities:**
+- Read job parameters from environment/bootstrap
+- Configure VRED render settings
+- Execute rendering (single frame or animation)
+- Handle region rendering (tiling) if enabled
+- Save output images
+
+### 5. VRED Integration Layer
+
+#### vred_utils Module
+- **Purpose**: Interfaces with VRED Python API
+- **Key Functions**: `get_scene_full_path()`, `get_render_filename()`, `get_frame_start()`, `get_frame_stop()`, `get_animation_clips_list()`, `get_render_quality()`, `get_render_view()`, `get_views_list()`, `get_all_file_references()`
+
+### 6. Plugin (`vred_submitter_plugin/plug-ins/DeadlineCloudForVRED.py`)
+
+Entry point that registers the "Deadline Cloud" menu in VRED's menu bar.
+
+## Job Bundle
+
+The job bundle is a directory containing:
+- `template.yaml` - Job template with parameters and steps
+- `parameter_values.yaml` - User-provided parameter values
+- `asset_references.yaml` - Scene file and dependency references
+- `scripts/VRED_RenderScript_DeadlineCloud.py` - Render script
+
+**Template Structure:**
+```yaml
+specificationVersion: jobtemplate-2023-09
+name: "VRED Render"
+parameterDefinitions:
+  - name: VREDSceneFile
+    type: PATH
+    objectType: FILE
+  - name: Frames
+    type: STRING
+  - name: RenderQuality
+    type: STRING
+  # ... more parameters
+
+steps:
+  - name: Render
+    parameterSpace:
+      taskParameterDefinitions:
+        - name: Frame
+          type: INT
+          range: "{{Param.Frames}}"
+    script:
+      actions:
+        onRun:
+          command: "..."
+```
+
+## Data Flow: Submitter to Render
+
+### 1. Job Submission
+```
+User fills dialog → Submitter creates bundle → Submit to Deadline Cloud
+                         |
+                         +-- template.yaml (job definition)
+                         +-- parameter_values.yaml (user settings)
+                         +-- asset_references.yaml
+                         +-- scripts/VRED_RenderScript_DeadlineCloud.py
+```
+
+### 2. Task Execution
+```
+Deadline Cloud assigns task to worker
+         |
+         v
+Worker launches VRED with bootstrap code
+         |
+         v
+VRED_RenderScript_DeadlineCloud.py executes
+         |
+         +-- Load scene file
+         +-- Configure render settings
+         +-- Set frame number
+         +-- Execute render
+         +-- Save output
+```
+
+## Adding a New Feature
+
+### Step 1: Submitter Changes
+1. Add UI controls to SceneSettingsWidget
+2. Add callbacks to SceneSettingsCallbacks
+3. Add population logic to SceneSettingsPopulator
+4. Add fields to RenderSubmitterUISettings
+5. Add parameters to default_vred_job_template.yaml
+6. Write parameter values to bundle in VREDSubmitter
+
+### Step 2: Render Script Changes
+1. Read new parameters in VRED_RenderScript_DeadlineCloud.py
+2. Configure VRED settings via VRED Python API
+3. Handle the new feature during rendering
+
+### Step 3: Utility Changes (if needed)
+1. Add VRED API wrapper functions to vred_utils.py
+2. Add shared utilities to utils.py
+
+## Render Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RenderQuality` | STRING | Analytic Low/High, Realistic Low/High, Raytracing, NPR |
+| `ImageWidth` | INT | Output image width |
+| `ImageHeight` | INT | Output image height |
+| `OutputDirectory` | PATH | Output directory |
+| `OutputFilename` | STRING | Output filename prefix |
+| `OutputFormat` | STRING | PNG, EXR, JPEG, TIFF, BMP, HDR |
+| `Frames` | STRING | Frame range expression |
+| `AnimationType` | STRING | Clip or Timeline |
+| `EnableRegionRendering` | STRING | Enable tiling |
+| `TilesX` | INT | Horizontal tile count |
+| `TilesY` | INT | Vertical tile count |
+| `UseGPURayTracing` | STRING | Enable GPU raytracing |
+
+## Testing Strategy
+
+1. **Unit tests** (`test/unit/`): Mock VRED APIs, test submitter logic
+2. **Submitter tests**: Automated GUI interaction, validate job bundle output
+3. **Worker tests** (`test/worker/`): Execute render script with VRED, compare output images
+4. **Integration tests** (`test/integ/`): End-to-end submitter-to-render validation
+
+## Project Structure
+
+```
+src/deadline/vred_submitter/
+├── ui/components/          # Qt UI components
+├── vred_submitter.py       # Main submitter orchestrator
+├── data_classes.py         # RenderSubmitterUISettings
+├── scene.py                # Scene utilities
+├── assets.py               # Asset introspection
+├── vred_utils.py           # VRED Python API interface
+├── qt_utils.py             # Qt utilities
+├── VRED_RenderScript_DeadlineCloud.py  # Worker render script
+└── default_vred_job_template.yaml      # Job template
+
+vred_submitter_plugin/
+└── plug-ins/
+    └── DeadlineCloudForVRED.py  # VRED plugin entry point
+
+test/
+├── unit/                   # Unit tests
+├── integ/                  # Integration tests (submitter + render)
+│   ├── helpers/            # Test utilities
+│   ├── scene_files/        # Test scene files
+│   └── expected_output/    # Expected outputs
+└── worker/                 # Worker render tests (if present)
+```

--- a/.kiro/powers/vred-design-power/steering/design-doc-structure.md
+++ b/.kiro/powers/vred-design-power/steering/design-doc-structure.md
@@ -1,0 +1,37 @@
+---
+inclusion: manual
+---
+
+# Design Document Structure
+
+Every design document for VRED features MUST follow this three-section structure:
+
+## 1. Data Structures to Change or Add
+
+Define all data model changes including:
+- New dataclasses or TypedDicts
+- Modifications to RenderSubmitterUISettings
+- Job parameter schemas
+- Configuration objects
+- Type annotations
+
+## 2. UX Changes (Submitter Dialog)
+
+Document all user-facing changes:
+- New UI controls (dropdowns, checkboxes, text fields)
+- Control placement and grouping
+- Default values and validation
+- Tooltips and help text
+- Conditional visibility logic
+- SceneSettingsCallbacks changes
+- SceneSettingsPopulator changes
+
+## 3. Job Template, Render Script, and Bundle Changes
+
+Specify modifications to:
+- `default_vred_job_template.yaml` structure
+- New parameters and their types
+- `VRED_RenderScript_DeadlineCloud.py` changes
+- Parameter dependencies and conditions
+- Asset references and attachments
+- VRED Python API calls needed for the feature

--- a/.kiro/powers/vred-design-power/steering/design-workflow.md
+++ b/.kiro/powers/vred-design-power/steering/design-workflow.md
@@ -1,0 +1,173 @@
+---
+inclusion: manual
+---
+
+# VRED Design Workflow Guide
+
+This guide walks through creating a comprehensive design document for a new VRED feature.
+
+## Step 1: Understand the Feature Request
+
+Before starting the design:
+1. Clarify the user's goal and expected outcome
+2. Identify which VRED components are affected (submitter UI, render script, job template)
+3. Determine if this is a new feature or modification to existing behavior
+4. Ask clarifying questions if the scope is unclear
+
+## Step 2: Research Phase
+
+### 2.1 Check Existing VRED Implementation
+
+Review the current codebase:
+- `src/deadline/vred_submitter/` - Submitter code
+- `src/deadline/vred_submitter/ui/components/` - UI components
+- `src/deadline/vred_submitter/data_classes.py` - Data structures
+- `src/deadline/vred_submitter/vred_utils.py` - VRED API wrappers
+- `src/deadline/vred_submitter/VRED_RenderScript_DeadlineCloud.py` - Render script
+- `src/deadline/vred_submitter/default_vred_job_template.yaml` - Job template
+
+### 2.2 Internet Research
+
+Search for:
+- VRED Python API documentation
+- Community solutions and workarounds
+- Known issues and limitations
+
+## Step 3: Design the Data Structures
+
+Data structures anchor the design - **always include full definitions** for new types:
+
+```python
+from typing import Optional
+from dataclasses import dataclass
+
+@dataclass
+class FeatureSettings:
+    """Settings for Feature X workflow."""
+    
+    enabled: bool = False
+    output_path: Optional[str] = None
+```
+
+Consider:
+- What data flows from submitter to render script?
+- What fields need to be added to RenderSubmitterUISettings?
+- What types should be used?
+
+## Step 4: Design the UX
+
+Sketch out the submitter dialog changes:
+
+1. **Control Type**: Dropdown, checkbox, text field, etc.
+2. **Placement**: Which group/section does it belong to?
+3. **Default Value**: What's the sensible default?
+4. **Validation**: What values are valid?
+5. **Dependencies**: Does it depend on other settings?
+
+Example:
+```
+Group: Render Options
+├── [Checkbox] Enable Feature X (default: unchecked)
+│   └── [Dropdown] Feature X Mode (visible when enabled)
+│       ├── Option A
+│       └── Option B
+└── [Text Field] Custom Path (optional)
+```
+
+## Step 5: Design Job Template Changes
+
+Define the job bundle modifications:
+
+```yaml
+parameterDefinitions:
+  - name: FeatureXEnabled
+    type: STRING
+    default: "false"
+    allowedValues: ["true", "false"]
+    
+  - name: FeatureXMode
+    type: STRING
+    default: "option_a"
+    allowedValues: ["option_a", "option_b"]
+    userInterface:
+      control: DROPDOWN
+      label: "Feature X Mode"
+```
+
+## Step 6: Design Render Script Changes
+
+Plan the render script implementation using concise inline snippets:
+
+```python
+# In VRED_RenderScript_DeadlineCloud.py
+def configure_feature_x(params):
+    """Configure Feature X before rendering."""
+    if params.get("FeatureXEnabled") == "true":
+        # VRED API calls here
+        ...
+```
+
+## Step 7: Plan Testing
+
+Define tests:
+
+```python
+def test_feature_x_job_bundle():
+    """Test Feature X parameters appear in job bundle."""
+    # Setup submitter with feature X enabled
+    # Export bundle
+    # Verify parameters in template.yaml and parameter_values.yaml
+
+def test_feature_x_rendering():
+    """Test Feature X produces correct output."""
+    # Load job bundle with feature X parameters
+    # Execute render script
+    # Compare output against expected
+```
+
+## Step 8: Document Files to Modify
+
+Create a summary table:
+
+| File | Changes |
+|------|---------|
+| `src/deadline/vred_submitter/ui/components/...` | Add UI controls |
+| `src/deadline/vred_submitter/data_classes.py` | Add settings fields |
+| `src/deadline/vred_submitter/default_vred_job_template.yaml` | Add parameters |
+| `src/deadline/vred_submitter/VRED_RenderScript_DeadlineCloud.py` | Add render logic |
+| `src/deadline/vred_submitter/vred_utils.py` | Add VRED API wrappers |
+| `test/unit/...` | Add unit tests |
+
+## Common Pitfalls
+
+1. **Forgetting standalone submitter**: Changes may need to work in both VRED-embedded and standalone modes
+2. **Missing type annotations**: All code needs proper types
+3. **No error handling**: VRED API operations can fail
+4. **Untested edge cases**: Test with missing/invalid data
+5. **Tiling interactions**: New features may interact with region rendering
+6. **Animation interactions**: Consider how the feature behaves with animation clips vs timeline
+
+## Step 9: Create the Appendix
+
+Put all full code implementations in a clearly marked appendix at the end of the design document.
+
+### Appendix Format
+
+```markdown
+---
+
+## Appendix: Full Code Implementations
+
+<!-- REVIEW: Brief description of what's new -->
+
+### A.1 ClassName.method_name (Full Implementation)
+
+**File:** `src/deadline/vred_submitter/...`
+
+\`\`\`python
+def method_name(self, data: dict) -> None:
+    """Full docstring here."""
+    # Complete implementation
+    ...
+\`\`\`
+```

--- a/.kiro/powers/vred-design-power/steering/external-references.md
+++ b/.kiro/powers/vred-design-power/steering/external-references.md
@@ -1,0 +1,24 @@
+---
+inclusion: manual
+---
+
+# External References
+
+Use these links when designing features. Only fetch URLs when the keywords match your design topic.
+
+## GitHub Repository
+
+| Keywords | Link | Description |
+|----------|------|-------------|
+| submitter, job bundle, template, parameters | [deadline-cloud-for-vred](https://github.com/aws-deadline/deadline-cloud-for-vred) | Main repository for VRED Deadline Cloud integration |
+| openjd, session, job template, step, task | [OpenJD Sessions](https://github.com/OpenJobDescription/openjd-sessions-for-python) | OpenJD Sessions for Python - runtime library for executing Open Job Description jobs |
+| deadline, client, submission, API | [deadline-cloud-client](https://github.com/aws-deadline/deadline-cloud) | AWS Deadline Cloud client library |
+| samples, job bundles, vred render | [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples) | Sample job bundles including VRED render examples |
+
+## Documentation
+
+| Keywords | Link | Description |
+|----------|------|-------------|
+| vred, requirements, system | [VRED System Requirements](https://www.autodesk.com/support/technical/article/caas/sfdcarticles/sfdcarticles/System-requirements-for-Autodesk-VRED-2026-products.html) | System requirements for VRED 2026 |
+| deadline cloud, user guide | [Deadline Cloud User Guide](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/what-is-deadline-cloud.html) | AWS Deadline Cloud service documentation |
+| job bundle, template | [Job Bundle Developer Guide](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/build-job-bundle.html) | How to build job bundles |

--- a/.kiro/powers/vred-design-power/steering/research-guide.md
+++ b/.kiro/powers/vred-design-power/steering/research-guide.md
@@ -1,0 +1,109 @@
+---
+inclusion: manual
+---
+
+# Research Guide for VRED Designs
+
+This guide covers how to research and validate design decisions for VRED features.
+
+## VRED Documentation Sources
+
+### Official Autodesk Documentation
+
+1. **VRED Python API**
+   - Search: "VRED Python API [topic]"
+   - Covers: VRED Python modules and functions
+
+2. **VRED System Requirements**
+   - URL: https://www.autodesk.com/support/technical/article/caas/sfdcarticles/sfdcarticles/System-requirements-for-Autodesk-VRED-2026-products.html
+   - Note: Autodesk websites are JS-rendered and may not be fetchable by web tools. If fetching fails, prompt the user to copy paste page contents, or use webscraping tools.
+
+## VRED Python API Patterns
+
+VRED exposes Python APIs through modules like `vrController`, `vrFileIO`, `vrRenderSettings`, etc. These are available when running inside the VRED process.
+
+### Common VRED API Modules
+
+| Module | Purpose |
+|--------|---------|
+| `vrController` | Application control, scene management |
+| `vrFileIO` | File I/O operations |
+| `vrRenderSettings` | Render configuration |
+| `vrCamera` | Camera/viewpoint management |
+| `vrScenegraph` | Scene graph access |
+| `vrNodeUtils` | Node utilities |
+
+### Bootstrap Code Injection
+
+VRED tests and the render script use bootstrap code injection to execute Python code inside VRED:
+
+```python
+# Bootstrap code is passed via BOOTSTRAP_CODE environment variable
+# VRED executes it on startup, which imports and runs the target module
+import os
+bootstrap = os.environ.get("BOOTSTRAP_CODE", "")
+if bootstrap:
+    exec(bootstrap)
+```
+
+## Key Integration Patterns
+
+### Scene File Access
+```python
+# Get current scene file path
+scene_path = vred_utils.get_scene_full_path()
+```
+
+### Render Settings
+```python
+# Get render quality, dimensions, etc.
+quality = vred_utils.get_render_quality()
+width, height = vred_utils.get_image_width(), vred_utils.get_image_height()
+```
+
+### Animation Data
+```python
+# Get animation information
+clips = vred_utils.get_animation_clips_list()
+start = vred_utils.get_frame_start()
+stop = vred_utils.get_frame_stop()
+```
+
+### File References
+```python
+# Get all file references for asset introspection
+references = vred_utils.get_all_file_references()
+```
+
+## Internet Research Guidelines
+
+### When to Search
+
+1. Documentation is unclear or incomplete
+2. Looking for version-specific behavior
+3. Finding community workarounds
+4. Verifying API behavior
+
+### Effective Search Queries
+
+- `"VRED" "Python API" "[feature]"`
+- `"VRED" "render settings" "[property]"`
+- `"Autodesk VRED" "[topic]" site:forums.autodesk.com`
+
+## Knowledge Gap Protocol
+
+When you encounter a knowledge gap:
+
+1. **Document what you know**
+   - What API/feature is involved?
+   - What have you found so far?
+   - What specific information is missing?
+
+2. **Ask the user clearly**
+   > "I need clarification on [topic]. Specifically:
+   > - [Question 1]
+   > - [Question 2]
+   > 
+   > Do you have documentation or code examples for this?"
+
+3. **Don't guess** - It's better to leave a gap clearly marked than to fill it with incorrect information. We can always add more detail later.

--- a/.kiro/powers/vred-dev-power/POWER.md
+++ b/.kiro/powers/vred-dev-power/POWER.md
@@ -1,0 +1,112 @@
+---
+name: "vred-dev-power"
+displayName: "VRED Dev Power"
+description: "Development power for deadline-cloud-for-vred - build, lint, test, and run integration tests with VRED."
+keywords: ["vred", "deadline", "build", "test", "lint", "integration", "render", "submitter"]
+author: "AWS Deadline Cloud Team"
+---
+
+# VRED Dev Power
+
+> All commands use PowerShell syntax.
+
+> **Terminal Output Pattern:** When running PowerShell commands that produce output you need to verify, always pipe to a temp file (`<command> | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8`), read it with `readFile`, then delete it. This avoids terminal output parsing issues.
+
+Development power for building, testing, and debugging the deadline-cloud-for-vred project.
+
+## Overview
+
+This project is a Python package that provides:
+- **VRED Submitter**: UI plugin for submitting render jobs from VRED to Deadline Cloud
+- **VRED Render Script**: `VRED_RenderScript_DeadlineCloud.py` that executes rendering on workers
+
+## Available Steering Files
+
+- **build-and-test.md** - Complete build and test workflow
+- **integration-testing.md** - Guide for running submitter, worker, and E2E integration tests
+- **troubleshooting.md** - Common issues and solutions
+
+## Prerequisites
+
+- Python 3.11+
+- VRED Pro 2025/2026 (for submitter/integration tests) or VRED Core (for worker tests)
+- Hatch (Python build tool): `pip install hatch`
+- Valid VRED BYOL license
+- (Optional) NVIDIA GPU with 4GB+ VRAM for worker tests
+- (Optional) ImageMagick for tile assembly tests
+
+## Quick Commands
+
+### Build
+```powershell
+hatch build
+```
+
+### Lint & Format
+```powershell
+hatch run fmt    # Format code (black + ruff)
+hatch run lint   # Run linter + type checker (ruff + black + mypy)
+hatch run typing # Type checking only (mypy)
+```
+
+### Unit Tests
+```powershell
+hatch run unit:test                          # All unit tests
+hatch run unit:test test/unit/test_scene.py  # Specific file
+hatch run unit:test -k "test_render"         # Pattern match
+```
+
+### Worker Tests (requires VRED + GPU)
+```powershell
+hatch run worker:test
+```
+
+### Integration Tests (requires VRED Pro)
+```powershell
+hatch run integ:test
+```
+
+## Test Types
+
+| Test Type | Command | Requirements |
+|-----------|---------|-------------|
+| Unit | `hatch run unit:test` | Python only |
+| Worker | `hatch run worker:test` | VRED Core/Pro + GPU |
+| Submitter | `hatch run submitter:test` | VRED Pro |
+| Integration | `hatch run integ:test` | VRED Pro + GPU |
+
+## Checking Logs
+
+```powershell
+# VRED Pro logs
+Get-ChildItem "$env:TEMP\VREDPro\log" -Filter "*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 5
+
+# VRED Core logs
+Get-ChildItem "$env:TEMP\VREDCore\log" -Filter "*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 5
+```
+
+## Project Structure
+
+```
+src/deadline/vred_submitter/
+├── ui/components/          # Qt UI components
+├── vred_submitter.py       # Main submitter
+├── data_classes.py         # Settings dataclass
+├── scene.py                # Scene utilities
+├── assets.py               # Asset introspection
+├── vred_utils.py           # VRED API wrappers
+├── VRED_RenderScript_DeadlineCloud.py  # Worker render script
+└── default_vred_job_template.yaml      # Job template
+
+vred_submitter_plugin/
+└── plug-ins/
+    └── DeadlineCloudForVRED.py  # VRED plugin entry point
+
+test/
+├── unit/                   # Unit tests (no VRED required)
+├── integ/                  # Integration tests
+│   ├── helpers/            # Test utilities (vred_runner, dialog controller, etc.)
+│   ├── scene_files/        # Test scene files (.vpb, .wire)
+│   └── expected_output/    # Expected outputs (bundle/ and render/)
+└── worker/                 # Worker render tests (if present)
+```

--- a/.kiro/powers/vred-dev-power/steering/build-and-test.md
+++ b/.kiro/powers/vred-dev-power/steering/build-and-test.md
@@ -1,0 +1,144 @@
+# Build and Test Workflow
+
+> All commands use PowerShell syntax.
+
+Complete build and test workflow for deadline-cloud-for-vred.
+
+## Step 1: Build the Wheel
+
+Always build a fresh wheel before testing:
+
+```powershell
+hatch build
+```
+
+This creates files in `dist/`:
+- `deadline_cloud_for_vred-*.whl`
+- `deadline_cloud_for_vred-*.tar.gz`
+
+To build only the wheel:
+```powershell
+hatch build -t wheel
+```
+
+## Step 2: Run Linting and Formatting
+
+Before committing, ensure code passes all checks:
+
+```powershell
+# Format code (black + ruff)
+hatch run fmt
+
+# Run full lint suite (ruff + black check + mypy)
+hatch run lint
+
+# Type checking only
+hatch run typing
+```
+
+Note: VRED uses both `ruff` and `black` for formatting (unlike 3ds Max which uses only ruff).
+
+## Step 3: Run Unit Tests
+
+Run the full unit test suite:
+
+```powershell
+hatch run unit:test
+```
+
+For faster iteration, run specific tests:
+
+```powershell
+# Run a single test file
+hatch run unit:test test/unit/test_vred_submitter.py
+
+# Run tests matching a pattern
+hatch run unit:test -k "test_render"
+
+# Run with verbose output
+hatch run unit:test -vvv
+```
+
+Unit tests do NOT require VRED to be installed. They mock VRED APIs.
+
+## Step 4: Run Worker Tests
+
+Worker tests execute actual VRED rendering and compare output images.
+
+**Prerequisites:**
+- VRED Core or Pro installed
+- NVIDIA GPU with 4GB+ VRAM
+- NVIDIA driver 553.xx recommended
+- `VREDCORE` or `VREDPRO` environment variable set
+- ImageMagick for tile assembly tests
+
+```powershell
+hatch run worker:test
+```
+
+## Step 5: Run Integration Tests
+
+Integration tests validate the complete workflow including submitter UI automation and rendering.
+
+**Prerequisites:**
+- VRED Pro installed (required for GUI dialog access)
+- `VREDPRO` environment variable set
+- Valid VRED license
+
+```powershell
+# All integration tests
+hatch run integ:test
+
+# Specific test file
+hatch run integ:test test/integ/test_vred_submitter.py
+
+# Only integ-marked tests
+hatch run integ:test_integ
+```
+
+## Step 6: Check Logs
+
+After running tests:
+
+```powershell
+# VRED Pro logs
+Get-ChildItem "$env:TEMP\VREDPro\log" -Filter "*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 5
+
+# View latest log
+$latestLog = Get-ChildItem "$env:TEMP\VREDPro\log" -Filter "*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+Get-Content $latestLog.FullName -Tail 100
+
+# Search for errors
+Select-String -Path "$env:TEMP\VREDPro\log\*.log" -Pattern "error|exception" -CaseSensitive:$false | Select-Object -Last 20
+```
+
+## Subnmitter Develpoment Workflow
+
+When changes to submitter, refer to DEVELOPMENT.md section on Submitter Development Workflow, make sure to follow the steps so that local development is reflected.
+
+## Common Issues
+
+### Hatch Environment Issues
+If tests behave unexpectedly, prune hatch environments:
+```powershell
+hatch env prune
+```
+
+### Wrong Python Version
+Ensure Python 3.11+ is being used. Write the check to a temp file:
+```powershell
+python --version 2>&1 | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+```
+Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+### VRED Process Stuck
+Kill stuck VRED processes:
+```powershell
+Get-Process VRED* | Stop-Process -Force
+```
+
+### Wheel Not Found
+Build the wheel first:
+```powershell
+hatch build -t wheel
+```

--- a/.kiro/powers/vred-dev-power/steering/dev-guide.md
+++ b/.kiro/powers/vred-dev-power/steering/dev-guide.md
@@ -1,0 +1,147 @@
+# Dev Guide
+
+> All commands use PowerShell syntax.
+
+## Reading Command Output Reliably
+
+When running PowerShell commands that produce output you need to verify, **always** use the temp-file pattern instead of reading terminal output directly:
+
+1. Pipe command output to a temp file: `<command> | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8`
+2. Read the file using the `readFile` tool on `deadline-cloud-for-vred/_check_result.txt`
+3. Delete the temp file using the `deleteFile` tool on `deadline-cloud-for-vred/_check_result.txt`
+
+## Python Environment
+
+VRED uses Python 3.11+. Unlike 3ds Max, VRED does not have its own embedded Python — it uses the system Python or the Python bundled with VRED's installation.
+
+## Build & Install Workflow
+
+### Build
+
+```powershell
+hatch build
+```
+
+This creates a wheel file in `dist/` folder.
+
+### Install Submitter to VRED
+
+After building, copy submitter files and install dependencies:
+
+```powershell
+# Install dependencies
+pip install --python-version 3.11 --only-binary=:all: "deadline[gui]" -t "$env:USERPROFILE\DeadlineCloudSubmitter\Submitters\VRED\python\modules"
+```
+
+Then follow the "After Code Changes" steps below to copy the source files.
+
+### Code Quality
+
+```powershell
+hatch run fmt      # Format code (black + ruff)
+hatch run lint     # Full lint (ruff + black check + mypy)
+hatch run typing   # Type checking only
+```
+
+### Unit Tests
+
+```powershell
+hatch run unit:test                              # All tests
+hatch run unit:test test/unit/test_scene.py      # Specific file
+hatch run unit:test -k "test_render"             # Pattern match
+```
+
+## After Code Changes
+
+Before copying, verify:
+- `$env:USERPROFILE` is set
+- `$env:VREDPRO` or `$env:VREDCORE` env var is set (derive `VRED_INSTALL` by going up 3 levels from the exe path)
+- Both destination directories exist
+
+Copy updated files:
+
+1. Submitter source:
+   ```powershell
+   Copy-Item -Path "src\deadline\vred_submitter\*" -Destination "$env:USERPROFILE\DeadlineCloudSubmitter\Submitters\VRED\scripts\deadline\vred_submitter\" -Recurse -Force
+   ```
+
+2. Plugin bootstrapper:
+   ```powershell
+   Copy-Item -Path "vred_submitter_plugin\plug-ins\DeadlineCloudForVRED.py" -Destination "<VRED_INSTALL>\lib\python\Lib\site-packages\"
+   ```
+   Where `<VRED_INSTALL>` is your VRED installation root (e.g. `C:\Program Files\Autodesk\VREDPro-18.0`).
+   Derive it from `$env:VREDPRO` or `$env:VREDCORE` by going up from the executable path.
+
+3. Restart VRED to pick up changes.
+
+## Submitter Development Workflow
+
+1. Modify submitter code in `src/deadline/vred_submitter/`
+2. Copy updated files to VRED's submitter directory
+3. Restart VRED to reload the plugin
+4. Set `DEADLINE_ENABLE_DEVELOPER_OPTIONS=true` for developer features
+5. Use "Export Bundle" to inspect generated job bundles
+6. Use "Submit" to test actual job submission
+
+## Integration Tests
+
+See **integration-testing.md** for full details.
+
+| Test Type | Command | What It Tests |
+|-----------|---------|---------------|
+| Unit | `hatch run unit:test` | Function-level logic, no VRED needed |
+| Worker | `hatch run worker:test` | Render script execution with VRED |
+| Submitter | `hatch run submitter:test` | Submitter UI and job bundle generation |
+| Integration | `hatch run integ:test` | Full E2E: submitter → render → validation |
+
+## Test Infrastructure
+
+### Bootstrap Code Injection
+
+VRED tests use a bootstrap code injection technique:
+1. Test parameters are encoded into Python code
+2. Passed to VRED via `BOOTSTRAP_CODE` environment variable
+3. VRED executes the bootstrap code on startup
+4. Bootstrap imports the test controller or render script
+
+This avoids the need for external GUI automation tools like Squish.
+
+### Test Helpers (`test/integ/helpers/`)
+
+| Helper | Purpose |
+|--------|---------|
+| `vred_runner.py` | VRED process execution and environment setup |
+| `submitter_dialog_controller.py` | Automated submitter UI manipulation |
+| `load_render_parameter_values.py` | Load render params from YAML |
+| `job_bundle_output_comparison.py` | Compare generated vs expected job bundles |
+| `output_comparison.py` | Image similarity comparison (PIL + NumPy) |
+| `sticky_settings_verification.py` | Validate settings persistence |
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `VREDPRO` | Path to VRED Pro executable |
+| `VREDCORE` | Path to VRED Core executable |
+| `DEADLINE_VRED_MODULES` | Path to submitter modules directory |
+| `DEADLINE_ENABLE_DEVELOPER_OPTIONS` | Enable developer features in submitter |
+| `MAGICK` | Path to ImageMagick executable |
+| `CONDA_CHANNELS` | Override conda channels |
+| `CONDA_PACKAGES` | Override conda packages |
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| No wheel found | `hatch build -t wheel` |
+| Hatch not found | `pip install hatch` |
+| Import errors | `hatch env prune` then retry |
+| VRED hangs | `Get-Process VRED* \| Stop-Process -Force` |
+| Python sandbox | Disable in VRED preferences or use `--disable-python-sandbox` |
+| License error | Check `ADSKFLEX_LICENSE_FILE` env var |
+| Submitter menu missing | Verify `DeadlineCloudForVRED.py` in site-packages |
+
+**Logs:**
+```powershell
+Get-ChildItem "$env:TEMP\VREDPro\log" -Filter "*.log" | Sort-Object LastWriteTime -Descending
+```

--- a/.kiro/powers/vred-dev-power/steering/integration-testing.md
+++ b/.kiro/powers/vred-dev-power/steering/integration-testing.md
@@ -1,0 +1,187 @@
+# Integration Testing Guide
+
+> All commands use PowerShell syntax.
+
+How to run and create integration tests for the VRED Deadline Cloud integration.
+
+## Test Architecture
+
+VRED has a three-tier testing architecture beyond unit tests:
+
+### 1. Submitter Tests (`test/integ/test_vred_submitter.py`)
+- Tests submitter UI and job bundle generation
+- Uses automated GUI interaction via bootstrap code injection
+- Requires VRED Pro (for GUI dialog access)
+- Compares generated job bundles against expected output in `test/integ/expected_output/bundle/`
+
+### 2. Worker/Render Tests (`test/integ/test_vred_render.py`)
+- Tests VRED rendering using OpenJD CLI to execute the job template
+- Requires VRED Core or Pro + NVIDIA GPU
+- Compares rendered images against expected output in `test/integ/expected_output/render/`
+
+### 3. Local E2E Tests (`test/integ/test_vred_local_e2e.py`)
+- Tests complete workflow: submitter UI → job bundle → render → validation
+- Phase 1: Launch VRED Pro, configure submitter, export job bundle
+- Phase 2: Load job bundle, execute VRED rendering
+- Phase 3: Compare both job bundle and rendered output against expected results
+
+### 4. Tile Assembly Tests (`test/integ/test_tile_assembler.py`)
+- Tests assembling image tiles into complete frames
+- Requires ImageMagick
+- Uses pre-generated tile images from `test/integ/tiles/`
+
+## Running Tests
+
+### Prerequisites
+
+| Test Type | VRED Pro | VRED Core | GPU | ImageMagick | License |
+|-----------|----------|-----------|-----|-------------|---------|
+| Submitter | ✅ Required | ❌ | ❌ | ❌ | ✅ BYOL |
+| Worker/Render | ❌ | ✅ Either | ✅ | ❌ | ✅ BYOL |
+| E2E | ✅ Required | ❌ | ✅ | ❌ | ✅ BYOL |
+| Tile Assembly | ❌ | ❌ | ❌ | ✅ | ❌ |
+
+### Commands
+
+```powershell
+# All integration tests
+hatch run integ:test
+
+# Submitter tests only
+hatch run integ:test test/integ/test_vred_submitter.py
+
+# Render tests only
+hatch run integ:test test/integ/test_vred_render.py
+
+# E2E tests only
+hatch run integ:test test/integ/test_vred_local_e2e.py
+
+# Tile assembly tests only
+hatch run integ:test test/integ/test_tile_assembler.py
+
+# Worker tests (separate hatch environment)
+hatch run worker:test
+```
+
+## How GUI Automation Works (No Squish Required)
+
+VRED's submitter tests use bootstrap code injection instead of external GUI tools:
+
+1. **Bootstrap Code Generation**: Test parameters (render settings) are encoded into Python code
+2. **Environment Variable Injection**: Bootstrap code is passed via `BOOTSTRAP_CODE` env var
+3. **VRED Launch**: VRED Pro launches with `--disable-python-sandbox` flag
+4. **Code Execution**: VRED executes the bootstrap code, which imports `submitter_dialog_controller`
+5. **Dialog Control**: Controller uses VRED's internal APIs (`vrController`, Qt widget access) to manipulate the submitter dialog programmatically
+6. **Bundle Export**: Controller triggers job bundle generation via the export button callback
+7. **VRED Termination**: Controller terminates VRED after export
+8. **Comparison**: Generated bundles are compared against expected output
+
+```
+Test runner → VRED launch → Bootstrap injection → Dialog controller
+    → Submitter API calls → Job bundle export → Output comparison
+```
+
+## Test Directory Structure
+
+```
+test/integ/
+├── helpers/
+│   ├── vred_runner.py                    # VRED process execution
+│   ├── submitter_dialog_controller.py    # Automated UI control
+│   ├── load_render_parameter_values.py   # YAML parameter loading
+│   ├── job_bundle_output_comparison.py   # Bundle comparison
+│   ├── output_comparison.py             # Image comparison (PIL + NumPy)
+│   ├── sticky_settings_verification.py  # Settings persistence validation
+│   └── constants.py                     # Shared constants
+├── scene_files/                         # Test scene files
+│   ├── Cone.vpb
+│   ├── FileReferencing.vpb
+│   └── test.wire
+├── expected_output/
+│   ├── bundle/                          # Expected job bundle outputs
+│   └── render/                          # Expected rendered images
+├── tiles/                               # Pre-generated tiles for assembly tests
+├── test_vred_submitter.py               # Submitter tests
+├── test_vred_render.py                  # Render tests
+├── test_vred_local_e2e.py              # E2E tests
+├── test_tile_assembler.py              # Tile assembly tests
+└── path_resolver.py                     # Path resolution utilities
+```
+
+## Output Comparison
+
+### Job Bundle Comparison
+- Template validation (`template.yaml`)
+- Parameter count and value comparison (`parameter_values.yaml`)
+- Asset reference filename comparison (`asset_references.yaml`)
+- Path normalization for environment-specific differences
+
+### Image Comparison
+- Image size and format validation
+- Pixel-level similarity using PIL and NumPy
+- Tolerance threshold for acceptable differences
+
+## E2E Testing Modes
+
+The testing strategy supports two execution modes:
+
+### Local Mode (Current)
+```
+Submitter → Job bundle → OpenJD CLI → VRED renders locally → Output comparison
+```
+- Runs entirely on local machine
+- Fast development iteration
+- No cloud infrastructure needed
+
+### Deadline Cloud Mode (Future)
+```
+Submitter → Job bundle → Submit to Deadline Cloud → SMF worker renders → Output download → Comparison
+```
+- Validates complete cloud workflow
+- Requires AWS account and Deadline Cloud farm
+
+## Developer Licensing for CI/CD
+
+For automated testing in CodeBuild environments, VRED requires developer licenses via SSM port forwarding:
+
+1. Assume cross-account role for developer licensing access
+2. Establish SSM port forwarding to license bastion
+3. Set `ADSKFLEX_LICENSE_FILE=2705@127.0.0.1`
+4. Run tests
+5. Clean up SSM sessions
+
+See the E2E testing documentation for full CodeBuild integration details.
+
+## Debugging
+
+### Check VRED Logs
+```powershell
+# Latest VRED Pro log
+Get-ChildItem "$env:TEMP\VREDPro\log" -Filter "*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1 | Get-Content -Tail 100
+
+# Search for errors
+Select-String -Path "$env:TEMP\VREDPro\log\*.log" -Pattern "error|exception" -CaseSensitive:$false | Select-Object -Last 20
+```
+
+### Kill Stuck VRED Processes
+```powershell
+Get-Process VRED* | Stop-Process -Force
+```
+
+### Verify Environment
+Write environment checks to a temp file and read back:
+```powershell
+@"
+VREDPRO=$($env:VREDPRO)
+VREDPRO_exists=$(Test-Path $env:VREDPRO)
+DEADLINE_VRED_MODULES=$($env:DEADLINE_VRED_MODULES)
+MODULES_exists=$(Test-Path $env:DEADLINE_VRED_MODULES)
+"@ | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+```
+Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+For ImageMagick:
+```powershell
+magick --version 2>&1 | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+```
+Then read and delete as above.

--- a/.kiro/powers/vred-dev-power/steering/troubleshooting.md
+++ b/.kiro/powers/vred-dev-power/steering/troubleshooting.md
@@ -1,0 +1,206 @@
+# Troubleshooting Guide
+
+> All commands use PowerShell syntax.
+
+Common issues and solutions when developing deadline-cloud-for-vred.
+
+## Reading Command Output Reliably
+
+When running PowerShell commands that produce output you need to verify, **always** use the temp-file pattern instead of reading terminal output directly:
+
+1. Pipe command output to a temp file: `<command> | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8`
+2. Read the file using the `readFile` tool on `deadline-cloud-for-vred/_check_result.txt`
+3. Delete the temp file using the `deleteFile` tool on `deadline-cloud-for-vred/_check_result.txt`
+
+## Build Issues
+
+### "No wheel files found in dist directory"
+```powershell
+hatch build -t wheel
+```
+
+### Hatch not found
+```powershell
+pip install hatch
+```
+
+### Build fails with version error
+Ensure git is initialized (hatch-vcs requires git tags):
+```powershell
+git status
+git describe --tags
+```
+
+## Test Issues
+
+### Unit tests fail with import errors
+```powershell
+# Prune and recreate hatch environments
+hatch env prune
+hatch run unit:test
+```
+
+Or install requirements manually:
+```powershell
+pip install -r requirements-testing.txt
+pip install -r requirements-unit-testing.txt
+```
+
+### Integration test hangs
+VRED may be waiting for user input or stuck. Kill processes:
+```powershell
+Get-Process VRED* | Stop-Process -Force
+```
+
+### Submitter tests fail - "VRED Pro not found"
+Submitter tests require VRED Pro (not Core). Write the check to a temp file:
+```powershell
+Test-Path $env:VREDPRO | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8 -NoNewline
+```
+Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+The VREDPRO env var should point to VREDPro.exe, e.g.:
+`C:\Program Files\Autodesk\VREDPro-18.0\bin\WIN64\VREDPro.exe`
+
+### Worker tests fail - no GPU
+Worker tests require an NVIDIA GPU. Write the check to a temp file:
+```powershell
+nvidia-smi 2>&1 | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+```
+Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+Check driver version (553.xx recommended for VRED 2025/2026).
+
+### Tile assembly tests fail
+Verify ImageMagick is installed and accessible. Write the check to a temp file:
+```powershell
+magick --version 2>&1 | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+```
+Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+Also check the MAGICK env var:
+```powershell
+$env:MAGICK | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8 -NoNewline
+```
+Then read and delete as above.
+
+## VRED Issues
+
+### VRED won't start - license error
+VRED requires BYOL licensing:
+1. Check license server accessibility
+2. Verify `ADSKFLEX_LICENSE_FILE` environment variable
+3. For developer licensing: `$env:ADSKFLEX_LICENSE_FILE = "2705@127.0.0.1"`
+
+### "builtins.builtins.exec blocked by python sandbox"
+Disable Python Sandbox:
+1. In VRED: `Edit → Preferences → General Settings → Script → Uncheck "Enable Python Sandbox"`
+2. Or launch with: `--disable-python-sandbox` flag
+3. Or add modules from `python-sandbox-module-allowlist.txt` to VRED preferences
+
+### Submitter menu not appearing in VRED
+1. Verify plugin file exists (write to temp file and read back):
+   ```powershell
+   Test-Path "C:\Program Files\Autodesk\VREDPro-18.0\lib\python\Lib\site-packages\DeadlineCloudForVRED.py" | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8 -NoNewline
+   ```
+   Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+2. Verify VRED preferences have the startup script configured
+3. Check VRED Console for errors
+
+### VRED renders solid black
+- Verify scene is configured for Raytracing (region rendering requires it)
+- Check lighting setup (raytracing needs proper light sources)
+- Verify camera exposure settings
+- Check render quality settings
+
+## Logging Issues
+
+### Can't find VRED logs
+```powershell
+# VRED Pro logs
+Get-ChildItem "$env:TEMP\VREDPro\log" -Filter "*.log" | Sort-Object LastWriteTime -Descending
+
+# VRED Core logs
+Get-ChildItem "$env:TEMP\VREDCore\log" -Filter "*.log" | Sort-Object LastWriteTime -Descending
+```
+
+### Need more verbose logging
+Set `FLEXLM_DIAGNOSTICS=3` for license diagnostics:
+```powershell
+$env:FLEXLM_DIAGNOSTICS = "3"
+```
+
+## Path Issues
+
+### Scene file not found
+1. Verify file exists: `Test-Path "path/to/scene.vpb"`
+2. Use forward slashes in YAML/JSON
+3. Check `parameter_values.yaml` paths
+
+### Output directory doesn't exist
+```powershell
+New-Item -ItemType Directory -Path "test/integ/output" -Force
+```
+
+### Submitter modules not found
+Verify `DEADLINE_VRED_MODULES` points to correct location. Write checks to a temp file:
+```powershell
+@"
+DEADLINE_VRED_MODULES=$($env:DEADLINE_VRED_MODULES)
+scripts_exist=$(Test-Path "$env:DEADLINE_VRED_MODULES\scripts\deadline\vred_submitter")
+modules_exist=$(Test-Path "$env:DEADLINE_VRED_MODULES\python\modules\deadline")
+"@ | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+```
+Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+## Python Environment Issues
+
+### Wrong Python version
+VRED requires Python 3.11+. Write the check to a temp file:
+```powershell
+python --version 2>&1 | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+```
+Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+### Hatch environment corrupted
+```powershell
+hatch env prune
+hatch run unit:test
+```
+
+## Render Issues
+
+### Region rendering produces black tiles
+- Region rendering only works with Raytracing quality
+- "Use GPU Ray Tracing" is automatically enabled with region rendering
+- Verify scene has proper lighting for raytracing
+
+### Color inconsistencies between Windows and Linux
+- Check tone mapper settings
+- Verify color space settings (sRGB/Reinhard/Linear)
+- Use compatible NVIDIA driver (553.xx)
+
+### Output images don't match expected
+- Check render quality settings
+- Verify image dimensions match
+- Check if DLSS or Super Sampling settings differ
+- Image comparison uses tolerance threshold - check if difference is within acceptable range
+
+## Getting Help
+
+If issues persist:
+
+1. Check project documentation:
+   - README.md
+   - DEVELOPMENT.md
+
+2. Check VRED logs for detailed error messages
+
+3. Verify all prerequisites:
+   - Python 3.11+
+   - VRED Pro/Core 2025/2026
+   - Valid BYOL license
+   - NVIDIA GPU + driver 553.xx (for worker tests)
+   - ImageMagick (for tile tests)
+
+4. Try a clean setup:
+   - `hatch env prune`
+   - `hatch build`
+   - Re-run tests

--- a/.kiro/powers/vred-dev-setup/POWER.md
+++ b/.kiro/powers/vred-dev-setup/POWER.md
@@ -1,0 +1,173 @@
+---
+name: vred-dev-setup
+version: 1.0.0
+displayName: VRED Dev Setup
+description: Automated development environment setup for deadline-cloud-for-vred - builds packages, installs dependencies, and configures environment variables
+keywords:
+  - vred
+  - deadline
+  - setup
+  - build
+  - install
+  - environment
+  - development
+  - hatch
+author: AWS Deadline Cloud
+---
+
+# VRED Dev Setup Power
+
+> All commands use PowerShell syntax.
+
+> **Terminal Output Pattern:** When running PowerShell commands that produce output you need to verify, always pipe to a temp file (`<command> | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8`), read it with `readFile`, then delete it. This avoids terminal output parsing issues.
+
+Automated development environment setup for deadline-cloud-for-vred project.
+
+## What This Power Does
+
+This power automates the complete development environment setup for working on the deadline-cloud-for-vred project. It handles everything from reading documentation to building packages, installing the submitter, and configuring environment variables.
+
+## Setup Steps Performed
+
+1. **Documentation Review** - Reads README.md and DEVELOPMENT.md to understand project requirements
+2. **Hatch Installation** - Installs and configures Hatch build tool
+3. **Package Build** - Builds wheel and source distributions
+4. **Installer Build** - Builds the Windows installer (if InstallBuilder is available)
+5. **VRED Detection** - Verifies VRED Pro or VRED Core installation
+6. **Submitter Installation** - Copies submitter files and installs dependencies to VRED modules directory
+7. **Plugin Installation** - Copies DeadlineCloudForVRED.py to VRED's site-packages
+8. **Test Dependencies** - Installs pytest, coverage, pillow, numpy, and other test packages
+9. **Environment Configuration** - Sets up required environment variables (VREDCORE, VREDPRO, DEADLINE_VRED_MODULES)
+
+## Prerequisites
+
+- Python 3.11+ installed on system
+- VRED Pro 2025/2026 or VRED Core 2025/2026 installed
+- Windows operating system
+- Valid VRED BYOL (Bring Your Own License)
+- (Optional) InstallBuilder for building installers
+- (Optional) ImageMagick for tile assembly testing
+
+## Usage
+
+The power will automatically scan `C:\Program Files\Autodesk\` for all installed VRED products and versions (e.g. VREDPro-18.0, VREDCore-17.3, VREDPro-17.0). It presents the discovered installations and lets you choose which one to set up for.
+
+If no VRED installation is found, the setup will abort with instructions to install VRED first.
+
+## What Gets Installed
+
+### System Python Packages
+- `hatch` - Build tool and environment manager
+- Development requirements from `requirements-development.txt`
+
+### Submitter Dependencies (installed to VRED modules directory)
+- `deadline[gui]` - AWS Deadline Cloud client library with GUI support
+- All required dependencies
+
+### Test Packages (via hatch environments)
+- `pytest` - Test framework
+- `pytest-cov` - Coverage plugin
+- `pytest-xdist` - Parallel test execution
+- `coverage` - Code coverage measurement
+- `pillow` - Image processing for render output comparison
+- `numpy` - Numerical operations for image comparison
+
+### Environment Variables
+- `VREDCORE` - Path to VRED Core executable (if using Core)
+- `VREDPRO` - Path to VRED Pro executable (if using Pro)
+- `DEADLINE_VRED_MODULES` - Path to submitter modules directory
+- `DEADLINE_ENABLE_DEVELOPER_OPTIONS` - Enables developer features in submitter UI
+- `MAGICK` - (Optional) Path to ImageMagick executable for tile assembly
+
+## VRED Installation Paths
+
+VRED uses versioned directory names under `C:\Program Files\Autodesk\`. The power dynamically discovers all installed versions. Common examples:
+- VRED Pro 2026: `C:\Program Files\Autodesk\VREDPro-18.0`
+- VRED Core 2026: `C:\Program Files\Autodesk\VREDCore-18.0`
+- VRED Pro 2025.3: `C:\Program Files\Autodesk\VREDPro-17.3`
+- VRED Pro 2025: `C:\Program Files\Autodesk\VREDPro-17.0`
+- VRED Core 2025: `C:\Program Files\Autodesk\VREDCore-17.0`
+
+Any version matching the pattern `VRED{Pro|Core}-X.Y` will be detected automatically.
+
+Executables are located at:
+- `C:\Program Files\Autodesk\VREDPro-18.0\bin\WIN64\VREDPro.exe`
+- `C:\Program Files\Autodesk\VREDCore-18.0\bin\WIN64\VREDCore.exe`
+
+## Submitter Installation Layout
+
+```
+$env:USERPROFILE\DeadlineCloudSubmitter\Submitters\VRED\
+├── scripts\deadline\vred_submitter\    # Submitter source files
+└── python\modules\                      # deadline[gui] and dependencies
+```
+
+The plugin file `DeadlineCloudForVRED.py` is copied to VRED's site-packages:
+- `C:\Program Files\Autodesk\VREDPro-18.0\lib\python\Lib\site-packages\`
+
+## After Setup
+
+Once setup is complete, you can:
+
+### Run Unit Tests
+```powershell
+hatch run unit:test
+```
+
+### Run Worker Tests (requires VRED + GPU)
+```powershell
+hatch run worker:test
+```
+
+### Run Integration Tests (requires VRED Pro)
+```powershell
+hatch run integ:test
+```
+
+### Build Package
+```powershell
+hatch build
+```
+
+### Format and Lint Code
+```powershell
+hatch run fmt
+hatch run lint
+```
+
+## Troubleshooting
+
+### Hatch Not Found
+If hatch is not found after installation, restart your terminal or add to PATH:
+```powershell
+$env:PATH = "C:\Users\$env:USERNAME\AppData\Roaming\Python\Python311\Scripts;$env:PATH"
+```
+
+### VRED Not Found
+Verify VRED is installed at the expected location (write to temp file and read back):
+```powershell
+Test-Path "C:\Program Files\Autodesk\VREDPro-18.0\bin\WIN64\VREDPro.exe" | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8 -NoNewline
+```
+Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+### Environment Variables Not Applied
+Environment variables are set at machine level. You may need to:
+1. Restart your terminal
+2. Restart VRED to pick up new environment variables
+
+### VRED Licensing Issues
+VRED requires BYOL licensing. Ensure your license server is accessible and `ADSKFLEX_LICENSE_FILE` is configured if needed.
+
+### Python Sandbox Issues
+If VRED blocks submitter execution, ensure Python Sandbox is disabled:
+- `Edit menu → Preferences → General Settings → Script → Uncheck "Enable Python Sandbox"`
+- Or launch VRED with `--disable-python-sandbox` flag
+
+## Notes
+
+- Setup requires Administrator privileges for setting machine-level environment variables
+- VRED requires BYOL licensing (no Hammersmark UBL support)
+- InstallBuilder is optional - installer build will be skipped if not found
+- ImageMagick is optional but required for tile assembly / region rendering tests
+- VRED Pro is required for submitter/integration tests (GUI dialog access)
+- VRED Core is sufficient for worker/render tests (headless rendering)

--- a/.kiro/powers/vred-dev-setup/steering/setup-guide.md
+++ b/.kiro/powers/vred-dev-setup/steering/setup-guide.md
@@ -1,0 +1,208 @@
+# VRED Dev Setup Guide
+
+> All commands use PowerShell syntax.
+
+Complete automated setup workflow for deadline-cloud-for-vred development environment.
+
+## Reading Command Output Reliably
+
+When running PowerShell commands that produce output you need to verify, **always** use the temp-file pattern instead of reading terminal output directly. Terminal output can be truncated or mixed with command echoes, making it unreliable.
+
+**Pattern:**
+1. Pipe command output to a temp file: `<command> | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8`
+2. Read the file using the `readFile` tool on `deadline-cloud-for-vred/_check_result.txt`
+3. Delete the temp file using the `deleteFile` tool on `deadline-cloud-for-vred/_check_result.txt`
+
+Use `-NoNewline` when you expect a single value (e.g. `True`/`False`). Omit it when expecting multi-line output.
+
+## Setup Workflow
+
+### Step 1: Discover Installed VRED Versions
+Instead of asking the user for a product and version upfront, dynamically scan for all installed VRED products. Write the result to a temp file and read it back (this avoids terminal output parsing issues):
+
+```powershell
+Get-ChildItem "C:\Program Files\Autodesk\VRED*" -Directory -ErrorAction SilentlyContinue | ForEach-Object { $_.Name } | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+```
+
+Then read the file using the `readFile` tool on `deadline-cloud-for-vred/_check_result.txt`. After reading, delete the temp file.
+
+**Interpreting the result:**
+- If the file lists one or more directory names (e.g. `VREDPro-18.0`, `VREDCore-17.3`), present them all to the user and ask which one to set up for.
+- If the file is empty, abort the setup. Tell the user: "No VRED installation found under C:\Program Files\Autodesk\. Please install VRED from https://manage.autodesk.com"
+
+Parse the chosen directory name to extract the product (`VREDPro` or `VREDCore`) and version (e.g. `18.0`, `17.3`, `17.0`). These values are used in all subsequent steps.
+
+**IMPORTANT:** Do NOT hardcode version numbers. Always use the values discovered from the filesystem. Do NOT use PowerShell variable interpolation (`${product}`) in commands — substitute the actual product name and version directly into path strings.
+
+### Step 2: Verify VRED Executable
+After the user picks an installation, confirm the executable exists. Write the result to a temp file and read it back:
+
+```powershell
+Test-Path "C:\Program Files\Autodesk\VREDPro-18.0\bin\WIN64\VREDPro.exe" | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8 -NoNewline
+```
+
+(Replace `VREDPro` and `18.0` with the user's chosen product and version.)
+
+Then read the file using the `readFile` tool on `deadline-cloud-for-vred/_check_result.txt`. After reading, delete the temp file.
+
+- If the file contains `True`: continue with setup.
+- If the file contains `False`: the directory exists but the executable is missing. Warn the user that the installation may be incomplete.
+
+Do NOT loop or retry this check — run it once and move on.
+
+### Step 3: Read Project Documentation
+Read and summarize key information from:
+1. `README.md` - Project overview, compatibility, requirements
+2. `DEVELOPMENT.md` - Development workflow, build instructions, manual installation steps
+
+### Step 4: Install Development Requirements
+```powershell
+pip install --upgrade -r requirements-development.txt
+```
+
+This installs hatch and other development tools.
+
+### Step 5: Install Hatch (if not already installed)
+Check if hatch is already installed by writing the result to a temp file:
+```powershell
+hatch --version 2>&1 | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+```
+
+Then read the file using the `readFile` tool on `deadline-cloud-for-vred/_check_result.txt`. After reading, delete the temp file.
+
+- If the file contains a version number (e.g. `0.x.x`): hatch is installed, continue.
+- If the file contains an error or "not recognized": install hatch:
+
+```powershell
+pip install hatch
+```
+
+### Step 6: Build the Package
+Build wheel and source distributions:
+```powershell
+hatch build
+```
+
+Expected output:
+- `dist/deadline_cloud_for_vred-{VERSION}-py3-none-any.whl`
+- `dist/deadline_cloud_for_vred-{VERSION}.tar.gz`
+
+### Step 7: Build the Installer (Optional)
+Check if InstallBuilder is available. If available:
+```powershell
+hatch run installer:build-installer --local-dev-build --platform windows
+```
+
+If InstallBuilder is not found, skip this step.
+
+### Step 8: Install Submitter to VRED
+Follow the manual installation steps from DEVELOPMENT.md:
+
+1. Create submitter directory and copy files:
+```powershell
+Copy-Item -Path "src\deadline\vred_submitter\*" -Destination "$env:USERPROFILE\DeadlineCloudSubmitter\Submitters\VRED\scripts\deadline\vred_submitter\" -Recurse -Force
+```
+
+2. Install submitter dependencies:
+```powershell
+pip install --python-version 3.11 --only-binary=:all: "deadline[gui]" -t "$env:USERPROFILE\DeadlineCloudSubmitter\Submitters\VRED\python\modules"
+```
+
+3. Copy plugin file to VRED's site-packages:
+```powershell
+$product = "VREDPro"  # or "VREDCore"
+$version = "18.0"
+Copy-Item "vred_submitter_plugin\plug-ins\DeadlineCloudForVRED.py" "C:\Program Files\Autodesk\${product}-${version}\lib\python\Lib\site-packages\"
+```
+
+### Step 9: Configure Environment Variables
+Set environment variables (Machine level):
+
+1. **VREDPRO or VREDCORE**
+```powershell
+# For VRED Pro:
+[Environment]::SetEnvironmentVariable('VREDPRO', 'C:\Program Files\Autodesk\VREDPro-18.0\bin\WIN64\VREDPro.exe', 'Machine')
+# For VRED Core:
+[Environment]::SetEnvironmentVariable('VREDCORE', 'C:\Program Files\Autodesk\VREDCore-18.0\bin\WIN64\VREDCore.exe', 'Machine')
+```
+
+2. **DEADLINE_VRED_MODULES**
+```powershell
+[Environment]::SetEnvironmentVariable('DEADLINE_VRED_MODULES', "$env:USERPROFILE\DeadlineCloudSubmitter\Submitters\VRED", 'Machine')
+```
+
+3. **DEADLINE_ENABLE_DEVELOPER_OPTIONS**
+```powershell
+[Environment]::SetEnvironmentVariable('DEADLINE_ENABLE_DEVELOPER_OPTIONS', 'true', 'Machine')
+```
+
+4. **MAGICK (Optional - if ImageMagick is detected)**
+Prompt user something like:
+
+" Do you want to check for ImageMagick? This is used for Tile Assembly Testing. "
+
+If yes, write the check result to a temp file and read it back:
+```powershell
+Get-ChildItem "C:\Program Files\ImageMagick*\magick.exe" -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8 -NoNewline
+```
+
+Then read the file using the `readFile` tool on `deadline-cloud-for-vred/_check_result.txt`. After reading, delete the temp file.
+
+- If the file contains a path: ImageMagick is installed. Set the environment variable:
+```powershell
+[Environment]::SetEnvironmentVariable('MAGICK', '<path from file>', 'Machine')
+```
+- If the file is empty: ImageMagick is not installed. Skip this step.
+
+### Step 10: Configure VRED Plugin Startup
+Remind the user to configure VRED to load the plugin on startup:
+1. Start VRED Pro
+2. Go to `Edit menu → Preferences → General Settings → Script`
+3. Uncheck "Enable Python Sandbox"
+4. Append to the script section:
+```python
+from DeadlineCloudForVRED import DeadlineCloudForVRED
+DeadlineCloudForVRED()
+```
+5. Click Save
+
+### Step 11: Display Setup Summary
+Show a summary of what was installed and configured:
+- Hatch version
+- Built packages
+- Submitter installation location
+- Environment variables set
+- Next steps
+
+## Example Summary Output
+
+```
+=== VRED Dev Setup Complete ===
+
+✅ Hatch installed
+✅ Package built: deadline_cloud_for_vred-{VERSION}
+✅ Submitter installed to $env:USERPROFILE\DeadlineCloudSubmitter\Submitters\VRED
+✅ Plugin copied to VREDPro-18.0 site-packages
+✅ Environment variables configured
+
+Environment Variables Set:
+- VREDPRO = C:\Program Files\Autodesk\VREDPro-18.0\bin\WIN64\VREDPro.exe
+- DEADLINE_VRED_MODULES = $env:USERPROFILE\DeadlineCloudSubmitter\Submitters\VRED
+- DEADLINE_ENABLE_DEVELOPER_OPTIONS = true
+
+Next Steps:
+1. Restart your terminal for environment variables to take effect
+2. Configure VRED to load the plugin (see Step 10 above)
+3. Restart VRED
+4. Run unit tests: hatch run unit:test
+5. Run worker tests: hatch run worker:test
+```
+
+## Important Notes
+
+- VRED Pro is required for submitter/integration tests (GUI dialog access)
+- VRED Core is sufficient for worker/render tests (headless rendering)
+- VRED requires BYOL licensing
+- Environment variables require terminal restart to take effect
+- Administrator privileges needed for machine-level environment variables
+- Python Sandbox must be disabled in VRED for the submitter to work

--- a/.kiro/powers/vred-dev-setup/steering/troubleshooting.md
+++ b/.kiro/powers/vred-dev-setup/steering/troubleshooting.md
@@ -1,0 +1,244 @@
+# Troubleshooting Guide
+
+> All commands use PowerShell syntax.
+
+Common issues and solutions for VRED dev setup.
+
+## Reading Command Output Reliably
+
+When running PowerShell commands that produce output you need to verify, **always** use the temp-file pattern instead of reading terminal output directly:
+
+1. Pipe command output to a temp file: `<command> | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8`
+2. Read the file using the `readFile` tool on `deadline-cloud-for-vred/_check_result.txt`
+3. Delete the temp file using the `deleteFile` tool on `deadline-cloud-for-vred/_check_result.txt`
+
+## VRED Not Found
+
+**Problem:** Setup aborts with "VRED is not installed"
+
+**Solutions:**
+1. Verify VRED is installed at the standard location:
+   ```
+   C:\Program Files\Autodesk\VREDPro-18.0\  (VRED Pro 2026)
+   C:\Program Files\Autodesk\VREDCore-18.0\ (VRED Core 2026)
+   ```
+
+2. Check the version number matches (18.0 for 2026, 17.0 for 2025)
+
+3. Install VRED from https://manage.autodesk.com
+
+## Hatch Installation Issues
+
+**Problem:** `hatch: The term 'hatch' is not recognized`
+
+**Solutions:**
+1. Verify hatch is installed (write to temp file and read back):
+   ```powershell
+   python -m pip list 2>&1 | Select-String "hatch" | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+   ```
+   Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+2. Add Scripts directory to PATH:
+   ```powershell
+   $env:PATH = "C:\Users\$env:USERNAME\AppData\Roaming\Python\Python311\Scripts;$env:PATH"
+   ```
+
+3. Restart terminal after installation
+
+## Build Failures
+
+**Problem:** `hatch build` fails
+
+**Solutions:**
+1. Ensure you're in the repository root directory
+
+2. Check if git is initialized (hatch-vcs requires git):
+   ```powershell
+   git status
+   ```
+
+3. Verify Python version (write to temp file and read back):
+   ```powershell
+   python --version 2>&1 | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+   ```
+   Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+4. Clean build artifacts and retry:
+   ```powershell
+   Remove-Item -Recurse -Force dist, build, *.egg-info -ErrorAction SilentlyContinue
+   hatch build
+   ```
+
+## Submitter Installation Issues
+
+**Problem:** Submitter files not found or not loading in VRED
+
+**Solutions:**
+1. Verify submitter files were copied (write to temp file and read back):
+   ```powershell
+   Test-Path "$env:USERPROFILE\DeadlineCloudSubmitter\Submitters\VRED\scripts\deadline\vred_submitter" | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8 -NoNewline
+   ```
+   Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+2. Verify plugin file was copied to VRED site-packages:
+   ```powershell
+   Test-Path "C:\Program Files\Autodesk\VREDPro-18.0\lib\python\Lib\site-packages\DeadlineCloudForVRED.py" | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8 -NoNewline
+   ```
+   Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+3. Verify DEADLINE_VRED_MODULES is set:
+   ```powershell
+   [Environment]::GetEnvironmentVariable('DEADLINE_VRED_MODULES', 'Machine') | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8 -NoNewline
+   ```
+   Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+4. Verify deadline[gui] dependencies are installed:
+   ```powershell
+   Test-Path "$env:USERPROFILE\DeadlineCloudSubmitter\Submitters\VRED\python\modules\deadline" | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8 -NoNewline
+   ```
+   Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+## VRED Licensing Issues
+
+**Problem:** VRED fails to start or reports license errors
+
+**Solutions:**
+1. VRED requires BYOL (Bring Your Own License) - ensure your license server is accessible
+
+2. Check ADSKFLEX_LICENSE_FILE environment variable (write to temp file and read back):
+   ```powershell
+   $env:ADSKFLEX_LICENSE_FILE | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8 -NoNewline
+   ```
+   Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+3. For developer licensing with SSM port forwarding:
+   ```powershell
+   $env:ADSKFLEX_LICENSE_FILE = "2705@127.0.0.1"
+   ```
+
+4. Check FlexLM diagnostics:
+   ```powershell
+   $env:FLEXLM_DIAGNOSTICS = "3"
+   ```
+
+## Python Sandbox Issues
+
+**Problem:** VRED reports "builtins.builtins.exec blocked by python sandbox"
+
+**Solutions:**
+1. Disable Python Sandbox in VRED preferences:
+   - `Edit menu → Preferences → General Settings → Script`
+   - Uncheck "Enable Python Sandbox"
+
+2. Or launch VRED with the flag:
+   ```powershell
+   & "C:\Program Files\Autodesk\VREDPro-18.0\bin\WIN64\VREDPro.exe" --disable-python-sandbox
+   ```
+
+3. If Python Sandbox must be enabled, add modules from `python-sandbox-module-allowlist.txt` to VRED's preferences
+
+## Environment Variables Not Applied
+
+**Problem:** Environment variables not recognized after setup
+
+**Solutions:**
+1. Restart terminal/PowerShell session
+
+2. Check if variables are set (write to temp file and read back):
+   ```powershell
+   @"
+   VREDPRO=$([Environment]::GetEnvironmentVariable('VREDPRO', 'Machine'))
+   DEADLINE_VRED_MODULES=$([Environment]::GetEnvironmentVariable('DEADLINE_VRED_MODULES', 'Machine'))
+   "@ | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+   ```
+   Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+3. Restart VRED to pick up new environment variables
+
+## Integration Test Failures
+
+**Problem:** Integration tests fail to run
+
+**Solutions:**
+1. Ensure VRED Pro is installed (not just Core) - submitter tests require Pro for GUI access
+
+2. Verify VREDPRO environment variable (write to temp file and read back):
+   ```powershell
+   $env:VREDPRO | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8 -NoNewline
+   ```
+   Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+3. Check that `C:\vred-snapshots` directory exists (used by submitter tests):
+   ```powershell
+   New-Item -ItemType Directory -Path "C:\vred-snapshots" -Force
+   ```
+
+4. Check VRED logs (write to temp file and read back):
+   ```powershell
+   Get-ChildItem "$env:TEMP\VREDPro\log" -Filter "*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 5 | Format-Table Name, LastWriteTime -AutoSize | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+   ```
+   Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+## Worker Test Failures
+
+**Problem:** Worker tests fail or produce incorrect output
+
+**Solutions:**
+1. Verify GPU is available (write to temp file and read back):
+   ```powershell
+   nvidia-smi 2>&1 | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+   ```
+   Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+2. Check NVIDIA driver version (553.xx recommended):
+   ```powershell
+   nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>&1 | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+   ```
+   Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+
+3. Verify VREDCORE or VREDPRO environment variable is set
+
+4. For tile assembly tests, verify ImageMagick (write to temp file and read back):
+   ```powershell
+   magick --version 2>&1 | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8
+   ```
+   Then read `deadline-cloud-for-vred/_check_result.txt` with `readFile` and delete after.
+   Also check MAGICK env var:
+   ```powershell
+   $env:MAGICK | Out-File "deadline-cloud-for-vred\_check_result.txt" -Encoding utf8 -NoNewline
+   ```
+   Then read and delete as above.
+
+## Permission Denied Errors
+
+**Problem:** Access denied when setting environment variables or copying files
+
+**Solutions:**
+1. Run PowerShell as Administrator for machine-level environment variables
+
+2. For copying to Program Files, use elevated permissions:
+   ```powershell
+   Start-Process powershell -Verb RunAs -ArgumentList "Copy-Item 'vred_submitter_plugin\plug-ins\DeadlineCloudForVRED.py' 'C:\Program Files\Autodesk\VREDPro-18.0\lib\python\Lib\site-packages\'"
+   ```
+
+## Module Import Errors
+
+**Problem:** `ModuleNotFoundError` when running tests
+
+**Solutions:**
+1. Verify test dependencies are installed:
+   ```powershell
+   hatch run unit:test --collect-only
+   ```
+
+2. Reinstall test requirements:
+   ```powershell
+   pip install -r requirements-testing.txt
+   pip install -r requirements-unit-testing.txt
+   ```
+
+3. Prune hatch environments and retry:
+   ```powershell
+   hatch env prune
+   hatch run unit:test
+   ```


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
VRED setup and developments are currently tedious.

### What was the solution? (How)
Added Kiro Powers, similar to the style of deadline-cloud-for-3ds-max, to allow new developers to easily onboard and develop for VRED.

### What is the impact of this change?
Users are now able to use powers that help them onboard and develop with VRED

### How was this change tested?
Used the powers myself to setup and develop a tiny change in my local VRED on windows instance. 
Added tweaks to powers as I went along, specifically for testing process

#### Please run the integration tests and paste the results below
Just doc changes, nothing to code.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

### Was this change documented?
Yes, in the powers are the docs.

### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
