### PR TITLE
docs: added section for adding to integ tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -241,6 +241,8 @@ Integration tests are located under the `test/integ` directory. These tests veri
 
 **To run the integration tests**: please see [README in integ folder](test/integ/README.md).
 
+> **Tip**: The integ README also covers [how to add new submitter tests](test/integ/README.md#adding-new-submitter-tests), including the base template pattern and parametrize usage.
+
 
 ### How To Install Submitter Manually
 #### Prerequisites

--- a/test/integ/README.md
+++ b/test/integ/README.md
@@ -21,6 +21,21 @@ integ/
 
 ```
 
+## Running the Tests
+
+From the repository root (Windows only, requires VRED installed):
+
+```bash
+hatch run integ:test
+```
+
+To run a specific test category or individual test:
+
+```bash
+hatch run integ:test -m submitter
+hatch run integ:test test/integ/test_vred_submitter.py::TestVREDSubmitter::test_submitter_dialog_basic_settings
+```
+
 ## Test Categories
 
 ### Submitter Tests (`test_vred_submitter.py`)
@@ -68,6 +83,77 @@ Pre-generated tile images for testing tile assembly functionality.
 ## Helper Modules
 
 The `helpers/` directory contains shared utilities. For detailed usage of helper functions, refer to the [README](./helpers/README.md)
+
+## Adding New Submitter Tests
+
+### The Test Helper Pattern
+
+All submitter tests in `test_vred_submitter.py` use the `_run_submitter_dialog_field_value_compare_test` helper. To add a new test, call it with:
+
+- `test_name`: A short identifier (e.g., `"dlss_quality"`, `"dpi"`)
+- `scene_name`: The scene file in `scene_files/` (e.g., `"Cone.vpb"`)
+- `parameter_overrides`: A dict of parameter names to values that the submitter UI should apply
+- `asset_overrides` (optional): A list of extra file reference paths, for tests that verify input file detection
+
+```python
+@pytest.mark.scene_files(Path("scene_files") / "Cone.vpb")
+def test_submitter_dialog_my_feature(self):
+    self._run_submitter_dialog_field_value_compare_test(
+        "my_feature",
+        "Cone.vpb",
+        {
+            "output_directories": ["c:\\vred-snapshots"],
+            "StartFrame": 0,
+            "EndFrame": 25,
+            "OutputDir": "c:\\vred-snapshots",
+            "OutputFileNamePrefix": "image",
+            "OutputFormat": "PNG",
+            "RenderAnimation": "false",
+            "View": "Front",
+            "MyNewParam": "some_value",
+        },
+    )
+```
+
+### Base Templates (Avoiding Per-Test Expected Output Folders)
+
+Instead of creating a full `parameter_values.yaml` and `asset_references.yaml` for every test case, the comparison helper can generate expected output at runtime by merging your `parameter_overrides` onto base templates in `expected_output/bundle/`:
+
+- `_base_parameter_values.yaml` — Default values for all job parameters
+- `_base_asset_{SceneName}.yaml` — Default asset references per scene file (e.g., `_base_asset_Cone.yaml`)
+
+When a test runs, the helper checks for a per-test expected folder (`expected_output/bundle/{SceneName}-{test_name}/`). If one exists, it uses those files directly. If not, it falls back to the base templates and applies your `parameter_overrides` on top.
+
+This means most new tests don't need an expected output folder, just provide the overrides and the base templates handle the rest. Only create a per-test folder when the expected output can't be expressed as overrides on the base (e.g., custom tiling templates, file referencing tests with unique asset structures).
+
+### Parametrize for Multi-Value Coverage
+
+Use `@pytest.mark.parametrize` to test multiple values of a single parameter without duplicating test methods or expected output:
+
+```python
+@pytest.mark.scene_files(Path("scene_files") / "Cone.vpb")
+@pytest.mark.parametrize("quality", ["Off", "Low", "Medium", "High", "Ultra High"])
+def test_submitter_dialog_ss_quality(self, quality):
+    self._run_submitter_dialog_field_value_compare_test(
+        "supersampling_quality",
+        "Cone.vpb",
+        {
+            ...
+            "SSQuality": quality,
+        },
+    )
+```
+
+Each parametrized value runs as a separate test case, all sharing the same base template logic.
+
+### Adding a New Scene File
+
+If your test requires a new scene file:
+
+1. Place the `.vpb` file in `scene_files/`
+2. Create a `_base_asset_{SceneName}.yaml` in `expected_output/bundle/` with the default asset references for that scene
+3. Use `@pytest.mark.scene_files(Path("scene_files") / "YourScene.vpb")` on the test
+4. If the new scene needs different base parameter defaults, consider whether a per-test expected folder is more appropriate
 
 ## Notes
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Lacked documentation explaining how to add integ tests to VRED in the improved format, instead of the old manual expected output for every test case.

### What was the solution? (How)
Added explanations in the integ folder README.md

### What is the impact of this change?
New users can learn about how to add integ tests.

### How was this change tested?
Added and reviewed test docs.

#### Please run the integration tests and paste the results below
N/A, only doc changes

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

### Was this change documented?
Yes, itself is the doc change.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
