### PR TITLE
ci: Add VRED integration test infrastructure

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,39 @@
+name: VRED Integration Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref_type:
+        description: 'Reference type to test'
+        required: true
+        default: 'branch'
+        type: choice
+        options:
+          - branch
+          - tag
+      branch:
+        description: 'Branch to test (e.g., mainline, feature-branch)'
+        required: false
+        default: 'mainline'
+        type: string
+      tag:
+        description: 'Tag to test (only used when ref_type is "tag")'
+        required: false
+        type: string
+  push:
+    branches:
+      - 'mainline'
+
+jobs:
+  IntegrationTests:
+    name: Windows Integration Tests
+    permissions:
+      id-token: write
+      contents: read
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      branch: ${{ github.event.inputs.ref_type == 'branch' && github.event.inputs.branch || 'mainline' }}
+      tag: ${{ github.event.inputs.ref_type == 'tag' && github.event.inputs.tag || '' }}
+      os: windows

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -243,6 +243,23 @@ Integration tests are located under the `test/integ` directory. These tests veri
 
 > **Tip**: The integ README also covers [how to add new submitter tests](test/integ/README.md#adding-new-submitter-tests), including the base template pattern and parametrize usage.
 
+##### CI Integration Tests
+
+Integration tests run automatically via the `.github/workflows/integration_tests.yml` workflow, which triggers on pushes to `mainline` or manually via `workflow_dispatch`.
+
+The `integ-ci` hatch environment (defined in `hatch.toml`) uses a matrix to test against VRED 2025 and 2026. It runs:
+
+1. `hatch run integ-ci:setup` — Installs VRED Pro for the target version.
+2. `hatch run integ-ci:test` — Runs the integration tests via pytest.
+
+A session-scoped fixture in `test/integ/conftest.py` syncs Windows registry environment variables into the process, since env vars written by installers during CI may not be visible to the test process.
+
+> **Note**: The CI integration tests are not yet passing — tests currently hang during execution. This is a known issue and is tracked as a TODO.
+>
+> **TODO**: Add integration test triggering as part of the release workflow.
+>
+> **TODO**: Add Linux support for VRED Core integration tests.
+
 
 ### How To Install Submitter Manually
 #### Prerequisites

--- a/hatch.toml
+++ b/hatch.toml
@@ -56,6 +56,32 @@ test = "pytest --cov=vred_submitter --cov-config pyproject.toml {args:test/unit}
 test = "pytest --no-cov {args:test/integ} -vvv --numprocesses=1"
 test_integ = "pytest --no-cov {args:test/integ} -vvv --numprocesses=1 -m integ"
 
+[envs.integ-ci]
+pre-install-commands = [
+  "pip install -r requirements-submitter-testing.txt",
+  "pip install -r requirements-worker-testing.txt",
+  "pip install -r requirements-testing.txt"
+]
+
+[[envs.integ-ci.matrix]]
+vred = ["2025"]
+
+[[envs.integ-ci.matrix]]
+vred = ["2026"]
+
+[envs.integ-ci.overrides]
+matrix.vred.env-vars = [
+  { key = "VREDPRO", value = "C:\\Program Files\\Autodesk\\VREDPro-17.3\\bin\\WIN64\\VREDPro.exe", if = ["2025"] },
+  { key = "VREDPRO", value = "C:\\Program Files\\Autodesk\\VREDPro-18.0\\bin\\WIN64\\VREDPro.exe", if = ["2026"] },
+]
+
+[envs.integ-ci.env-vars]
+VRED_VERSION = "{matrix:vred}"
+
+[envs.integ-ci.scripts]
+setup = "python ./pipeline/setup-runner.py --versions {matrix:vred} {args}"
+test = "pytest --no-cov {args:test/integ} -vvv -p no:xdist -s"
+
 [envs.codebuild.env-vars]
 SKIP_BOOTSTRAP_TEST_RESOURCES="True"
 

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Setup runner for VRED integration tests in CodeBuild."""
+
+import argparse
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+VRED_VERSIONS = ["2025", "2026"]
+
+# S3 paths for VRED installers (relative to INSTALLER_BUCKET)
+VRED_S3_PATHS = {
+    "2025": "vred/2025/VREDPro2025.zip",
+    "2026": "vred/2026/VREDPro2026.zip",
+}
+
+# Install paths for VRED Pro on Windows
+VRED_INSTALL_PATHS = {
+    "2025": r"C:\Program Files\Autodesk\VREDPro-17.3",
+    "2026": r"C:\Program Files\Autodesk\VREDPro-18.0",
+}
+
+VRED_EXE_PATHS = {
+    "2025": r"C:\Program Files\Autodesk\VREDPro-17.3\bin\WIN64\VREDPro.exe",
+    "2026": r"C:\Program Files\Autodesk\VREDPro-18.0\bin\WIN64\VREDPro.exe",
+}
+
+
+def run(cmd, check=True, shell=False):
+    """Run a command and optionally check for errors."""
+    print(f"Running: {cmd if shell else ' '.join(cmd)}")
+    result = subprocess.run(cmd, shell=shell)
+    if check and result.returncode != 0:
+        print(f"Command failed with return code {result.returncode}")
+        sys.exit(result.returncode)
+    return result
+
+
+def download_from_s3(s3_path, local_path):
+    """Download a file from S3 installer bucket."""
+    bucket = os.environ.get("INSTALLER_BUCKET")
+    if not bucket:
+        print("ERROR: INSTALLER_BUCKET environment variable not set")
+        return False
+
+    cmd = ["aws", "s3", "cp", f"s3://{bucket}/{s3_path}", str(local_path), "--no-progress"]
+
+    run(cmd)
+    return True
+
+
+def find_setup_exe(extract_path):
+    """Locate Setup.exe in the extracted installer directory."""
+    setup_exe = extract_path / "Setup.exe"
+    if setup_exe.exists():
+        return setup_exe
+
+    for subdir in extract_path.iterdir():
+        if subdir.is_dir():
+            potential_setup = subdir / "Setup.exe"
+            if potential_setup.exists():
+                return potential_setup
+
+    return None
+
+
+def run_installer(setup_exe):
+    """Run the VRED silent installer and log output."""
+    print(f"Running silent install: {setup_exe} -q -i install")
+    result = subprocess.run(
+        [str(setup_exe), "-q", "-i", "install"],
+        capture_output=True,
+        text=True,
+    )
+    print(f"Installer exit code: {result.returncode}")
+    if result.stdout:
+        print(f"Installer stdout: {result.stdout}")
+    if result.stderr:
+        print(f"Installer stderr: {result.stderr}")
+
+
+def print_autodesk_logs():
+    """Print recent Autodesk installer logs for debugging."""
+    autodesk_log_dir = (
+        Path(os.environ.get("LOCALAPPDATA", "C:/Users/Default/AppData/Local"))
+        / "Autodesk"
+        / "ODIS"
+        / "logs"
+    )
+    if not autodesk_log_dir.exists():
+        return
+
+    print(f"Autodesk logs found at: {autodesk_log_dir}")
+    recent_logs = sorted(
+        autodesk_log_dir.glob("*.log"), key=lambda x: x.stat().st_mtime, reverse=True
+    )[:3]
+    for log in recent_logs:
+        print(f"--- {log.name} (last 50 lines) ---")
+        try:
+            lines = log.read_text(errors="ignore").splitlines()[-50:]
+            print("\n".join(lines))
+        except Exception as e:
+            print(f"Could not read log: {e}")
+
+
+def verify_installation(install_path, marker_file, version):
+    """Verify VRED installation and create marker file on success."""
+    if install_path.exists():
+        marker_file.touch()
+        print(f"VRED Pro {version} installed successfully")
+        return
+
+    print(f"WARNING: Install path {install_path} not found after installation")
+    autodesk_dir = Path("C:/Program Files/Autodesk")
+    if autodesk_dir.exists():
+        print(f"Contents of {autodesk_dir}:")
+        for item in autodesk_dir.iterdir():
+            print(f"  {item.name}")
+
+
+def download_and_extract(version):
+    """Download and extract the VRED installer. Returns (zip_path, extract_path)."""
+    zip_path = Path(f"C:/Temp/VREDPro{version}.zip")
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not download_from_s3(VRED_S3_PATHS[version], zip_path):
+        print(f"ERROR: Failed to download VRED {version} installer")
+        sys.exit(1)
+
+    extract_path = Path(f"C:/Temp/VREDPro{version}")
+    run(
+        [
+            "powershell",
+            "-Command",
+            f"Expand-Archive -Path '{zip_path}' -DestinationPath '{extract_path}' -Force",
+        ]
+    )
+    return zip_path, extract_path
+
+
+def install_vred_version(version):
+    """Install a single VRED version."""
+    install_path = Path(VRED_INSTALL_PATHS[version])
+    marker_file = install_path / ".installed"
+
+    if marker_file.exists():
+        print(f"VRED Pro {version} already installed at {install_path}")
+        return
+
+    print(f"Installing VRED Pro {version}...")
+    zip_path, extract_path = download_and_extract(version)
+
+    setup_exe = find_setup_exe(extract_path)
+    if not setup_exe:
+        print(f"ERROR: Setup.exe not found in {extract_path}")
+        sys.exit(1)
+
+    run_installer(setup_exe)
+    print_autodesk_logs()
+    verify_installation(install_path, marker_file, version)
+    zip_path.unlink(missing_ok=True)
+
+
+def setup_windows(versions):
+    """Set up VRED Pro on Windows."""
+    for version in versions:
+        install_vred_version(version)
+
+    print("Installing VRED submitter from current branch...")
+    run(["pip", "install", "--force-reinstall", "-e", "."])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Setup VRED test environment")
+    parser.add_argument(
+        "--versions",
+        nargs="+",
+        default=VRED_VERSIONS,
+        help="VRED versions to install (e.g., 2025 2026)",
+    )
+
+    args = parser.parse_args()
+
+    system = platform.system()
+    print(f"Setting up {system} with VRED {', '.join(args.versions)}")
+
+    if system != "Windows":
+        print("ERROR: VRED Pro is only supported on Windows")
+        sys.exit(1)
+
+    setup_windows(args.versions)
+
+    print("Setup complete!")

--- a/test/integ/conftest.py
+++ b/test/integ/conftest.py
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def sync_machine_env_vars():
+    """
+    On Windows, read machine-level environment variables from the registry
+    and merge any missing ones into the current process's os.environ.
+
+    Machine-level env vars (e.g. VREDPRO set by the VRED installer) live in
+    the registry. A running process only sees them if it was started AFTER
+    they were written, AND the parent process propagated them. In CI
+    (CodeBuild), the agent process may have been started before the installer
+    ran, so its children never inherit the new vars even though they exist in
+    the registry.
+    """
+    if os.name != "nt":
+        return
+
+    import winreg  # type: ignore[import-not-found]
+
+    try:
+        with winreg.OpenKey(  # type: ignore[attr-defined]
+            winreg.HKEY_LOCAL_MACHINE,  # type: ignore[attr-defined]
+            r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
+        ) as key:
+            i = 0
+            while True:
+                try:
+                    name, value, _ = winreg.EnumValue(key, i)  # type: ignore[attr-defined]
+                    if name not in os.environ:
+                        os.environ[name] = value
+                        print(f"Synced machine env var: {name}={value}")
+                    i += 1
+                except OSError:
+                    break
+    except OSError as e:
+        print(f"WARNING: Could not read machine env vars from registry: {e}")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The deadline-cloud-for-vred github repository lacks CI testing, which can benefit our development and release speed.

### What was the solution? (How)
Following the CI process for deadline-cloud-for-blender and deadline-cloud-for-houdini

Note, the CI testing does not fully work as intended. The VRED codebuild testing pipeline and Github workflow successfully sets up, installs and extracts VRED, and successfully installs all dependancies. Dev licensing tunnel sets up and runs as a process on codebuild.

Next Steps: Integ tests start running, however hangs indefinitely. Note that we never get confirmation that a license has been checked out.. I've double checked that ADSK_LICENSE has port set to 2702@localhost. Need to dig deeper per this issue.
```
Setting up Windows with VRED 2026
VRED Pro 2026 already installed at C:\Program Files\Autodesk\VREDPro-18.0
Installing VRED submitter from current branch...
Running: pip install -e .
Setup complete!

[Instance] 2026/03/05 07:46:26.876762 Running command hatch run integ-ci:test test/integ/test_vred_render.py::test_vred_render_openjd_gpu_raytracing
-------------------------------- integ-ci.2025 --------------------------------
============================= test session starts =============================
platform win32 -- Python 3.13.2, pytest-9.0.2, pluggy-1.6.0 -- C:\Windows\System32\config\systemprofile\AppData\Local\hatch\env\virtual\deadline-cloud-for-vred\Fg_0Odpv\integ-ci.2025\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Windows\Temp\codebuild-61a50dae-c960-41c0-a298-cb3f532dc8a8\tmp\output\src1111\src\github.com\seant-aws\deadline-cloud-for-vred
configfile: pyproject.toml
plugins: cov-7.0.0, xdist-3.8.0
created: 1/1 worker
1 worker [1 item]

scheduling tests via LoadScheduling

test/integ/test_vred_render.py::test_vred_render_openjd_gpu_raytracing debug1: client_input_global_request: rtype keepalive@openssh.com want_reply 1
debug1: client_input_global_request: rtype keepalive@openssh.com want_reply 1
debug1: client_input_global_request: rtype keepalive@openssh.com want_reply 1
debug1: client_input_global_request: rtype keepalive@openssh.com want_reply 1
```
### What is the impact of this change?
Github is now able to trigger workflow to automatically run integ test.

### How was this change tested?
Deployed with DEVO pipeline in internal dev account, connecting to personal fork under https://github.com/seant-aws/deadline-cloud-for-vred.

Under github actions, ran workflow, which triggered a codebuild run.
```
Source provider
  GitHub
Source identifier
  Repository
  seant-aws/deadline-cloud-for-vred 
Source version
  mainline

...
<TRUNCATED LOGS>


Successfully installed deadline-cloud-for-vred-0.0.post105+geba80abb3
Setting up Windows with VRED 2025
VRED Pro 2025 already installed at C:\Program Files\Autodesk\VREDPro-17.3
Installing VRED submitter from current branch...
Running: pip install -e .
Setup complete!

-------------------------------- integ-ci.2025 --------------------------------
============================= test session starts =============================
platform win32 -- Python 3.13.2, pytest-9.0.2, pluggy-1.6.0 -- C:\Windows\System32\config\systemprofile\AppData\Local\hatch\env\virtual\deadline-cloud-for-vred\Fg_0Odpv\integ-ci.2025\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Windows\Temp\codebuild-61a50dae-c960-41c0-a298-cb3f532dc8a8\tmp\output\src1111\src\github.com\seant-aws\deadline-cloud-for-vred
configfile: pyproject.toml
plugins: cov-7.0.0, xdist-3.8.0
created: 1/1 worker
1 worker [1 item]

scheduling tests via LoadScheduling
```
#### Please run the integration tests and paste the results below
No change directly to code, just infrastructure and workflow changes.

### Was this change documented?
Yes, in `Development.md`

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
