### PR TITLE
feat: Notify customers if newer submitter is available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 
 dependencies = [
-    "deadline >= 0.51.1,< 0.55",
+    "deadline >= 0.55.1,< 0.56",
 ]
 
 [project.scripts]

--- a/src/deadline/vred_submitter/update_utils.py
+++ b/src/deadline/vred_submitter/update_utils.py
@@ -1,0 +1,67 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Utilities for checking and displaying update notifications."""
+
+import logging
+from dataclasses import dataclass
+
+from deadline.client.api import safe_check_for_updates, UpdateCheckResult, UpdateCheckStatus
+from deadline.client.ui.dialogs.update_available_dialog import UpdateAvailableDialog
+
+from ._version import version_tuple as adaptor_version_tuple
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _SessionState:
+    """Session-level state: once the user dismisses the update dialog,
+    don't show it again until VRED is restarted."""
+
+    update_dismissed: bool = False
+
+
+_session_state = _SessionState()
+
+
+def _check_for_update() -> UpdateCheckResult:
+    """Check if a newer version of the VRED submitter is available.
+
+    Returns:
+        An UpdateCheckResult describing whether an update is available.
+    """
+    current_version = ".".join(str(v) for v in adaptor_version_tuple[:3])
+    return safe_check_for_updates(
+        integration_name="deadline-cloud-for-vred",
+        current_version=current_version,
+    )
+
+
+def check_and_show_update_dialog() -> bool:
+    """Check for updates and show the update dialog if one is available.
+
+    If the user previously dismissed the dialog in this VRED session,
+    the check is skipped entirely.
+
+    Returns:
+        True if the user clicked Download (caller should skip opening the submitter),
+        False otherwise.
+    """
+    if _session_state.update_dismissed:
+        return False
+
+    update_result = _check_for_update()
+    if update_result.status == UpdateCheckStatus.SUCCESS and update_result.update_available:
+        update_dialog = UpdateAvailableDialog(
+            integration_name="VRED",
+            current_version=update_result.current_version or "",
+            latest_version=update_result.latest_version or "",
+            download_url=update_result.download_url or "",
+            release_notes_url="https://github.com/aws-deadline/deadline-cloud-for-vred/releases",
+        )
+        update_dialog.exec_()
+        if update_dialog.user_downloaded:
+            return True
+        # User dismissed — suppress for the rest of this VRED session
+        _session_state.update_dismissed = True
+    return False

--- a/src/deadline/vred_submitter/vred_submitter_wrapper.py
+++ b/src/deadline/vred_submitter/vred_submitter_wrapper.py
@@ -7,6 +7,7 @@ VRED menu for Deadline Cloud. This menu effectively triggers the Deadline Cloud 
 from typing import Any, Optional
 
 from .constants import Constants
+from .update_utils import check_and_show_update_dialog
 from .vred_submitter import VREDSubmitter
 from .vred_utils import assign_scene_transition_event, get_main_window
 
@@ -67,5 +68,9 @@ def submit_to_deadline_cloud() -> None:
         _global_submitter_dialog.raise_()
         _global_submitter_dialog.activateWindow()
         return
+
+    if check_and_show_update_dialog():
+        return
+
     submitter = VREDSubmitter(get_main_window(), Qt.Tool)
     _global_submitter_dialog = submitter.show_submitter()

--- a/test/unit/test_update_utils.py
+++ b/test/unit/test_update_utils.py
@@ -1,0 +1,193 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from deadline.client.api import UpdateCheckResult, UpdateCheckStatus
+
+from deadline.vred_submitter.update_utils import (
+    _check_for_update,
+    _session_state,
+    check_and_show_update_dialog,
+)
+
+MODULE = "deadline.vred_submitter.update_utils"
+
+
+@pytest.fixture(autouse=True)
+def _reset_session_state():
+    """Reset session state before each test."""
+    _session_state.update_dismissed = False
+
+
+class TestCheckForUpdate:
+    """Tests for _check_for_update()."""
+
+    @patch(f"{MODULE}.safe_check_for_updates")
+    def test_passes_correct_integration_name(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.5.1",
+        )
+
+        # WHEN
+        _check_for_update()
+
+        # THEN
+        call_kwargs = mock_check.call_args[1]
+        assert call_kwargs["integration_name"] == "deadline-cloud-for-vred"
+
+    @patch(f"{MODULE}.safe_check_for_updates")
+    def test_passes_major_minor_patch_current_version(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="1.2.3",
+        )
+
+        # WHEN
+        with patch(f"{MODULE}.adaptor_version_tuple", (1, 2, 3, "post4", "gabc123")):
+            _check_for_update()
+
+        # THEN
+        call_kwargs = mock_check.call_args[1]
+        assert call_kwargs["current_version"] == "1.2.3"
+
+
+class TestCheckAndShowUpdateDialog:
+    """Tests for check_and_show_update_dialog()."""
+
+    @patch(f"{MODULE}._check_for_update")
+    def test_returns_false_when_no_update(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.5.1",
+            update_available=False,
+        )
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+
+    @patch(f"{MODULE}._check_for_update")
+    def test_returns_false_on_error_status(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.NETWORK_ERROR,
+            current_version="0.5.1",
+            update_available=False,
+        )
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+
+    @patch(f"{MODULE}.UpdateAvailableDialog")
+    @patch(f"{MODULE}._check_for_update")
+    def test_returns_true_when_user_downloads(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.5.1",
+            update_available=True,
+            latest_version="0.6.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = True
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is True
+        mock_dialog.exec_.assert_called_once()
+
+    @patch(f"{MODULE}.UpdateAvailableDialog")
+    @patch(f"{MODULE}._check_for_update")
+    def test_dismiss_sets_session_state(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.5.1",
+            update_available=True,
+            latest_version="0.6.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = False
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+        assert _session_state.update_dismissed is True
+
+    @patch(f"{MODULE}._check_for_update")
+    def test_skips_check_when_previously_dismissed(self, mock_check):
+        # GIVEN
+        _session_state.update_dismissed = True
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+        mock_check.assert_not_called()
+
+    @patch(f"{MODULE}.UpdateAvailableDialog")
+    @patch(f"{MODULE}._check_for_update")
+    def test_download_does_not_set_dismissed(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.5.1",
+            update_available=True,
+            latest_version="0.6.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = True
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        check_and_show_update_dialog()
+
+        # THEN
+        assert _session_state.update_dismissed is False
+
+    @patch(f"{MODULE}.UpdateAvailableDialog")
+    @patch(f"{MODULE}._check_for_update")
+    def test_dialog_receives_correct_release_notes_url(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.5.1",
+            update_available=True,
+            latest_version="0.6.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = False
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        check_and_show_update_dialog()
+
+        # THEN
+        call_kwargs = mock_dialog_cls.call_args[1]
+        assert (
+            call_kwargs["release_notes_url"]
+            == "https://github.com/aws-deadline/deadline-cloud-for-vred/releases"
+        )

--- a/test/unit/test_vred_submitter_wrapper.py
+++ b/test/unit/test_vred_submitter_wrapper.py
@@ -118,9 +118,10 @@ class TestAddDeadlineCloudMenu:
 class TestSubmitToDeadlineCloud:
     """Tests for submit_to_deadline_cloud function"""
 
+    @patch("vred_submitter.vred_submitter_wrapper.check_and_show_update_dialog", return_value=False)
     @patch("vred_submitter.vred_submitter_wrapper.get_main_window")
     @patch("vred_submitter.vred_submitter_wrapper.VREDSubmitter")
-    def test_singleton_behavior(self, mock_submitter_cls, mock_get_window):
+    def test_singleton_behavior(self, mock_submitter_cls, mock_get_window, mock_check_update):
         # Verify dialog singleton pattern implementation
         from vred_submitter import vred_submitter_wrapper
 
@@ -141,9 +142,10 @@ class TestSubmitToDeadlineCloud:
         mock_submitter.show_submitter.assert_called_once()
         assert vred_submitter_wrapper._global_submitter_dialog == mock_dialog
 
+    @patch("vred_submitter.vred_submitter_wrapper.check_and_show_update_dialog", return_value=False)
     @patch("vred_submitter.vred_submitter_wrapper.get_main_window")
     @patch("vred_submitter.vred_submitter_wrapper.VREDSubmitter")
-    def test_reuses_existing_dialog(self, mock_submitter_cls, mock_get_window):
+    def test_reuses_existing_dialog(self, mock_submitter_cls, mock_get_window, mock_check_update):
         # Ensure existing dialog is reused and raised
         from vred_submitter import vred_submitter_wrapper
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Customers did not know whether they were on the latest submitter or not. This means they would not have the latest bug fixes or features to work with our product. 

This is based off a similar PR for Cinema 4D: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/414

### What was the solution? (How)

This adds a dialog which checks our download manifests and if there's a new update available notifies customer  that. 

<img width="470" height="197" alt="image" src="https://github.com/user-attachments/assets/6b5f2ba3-5814-47a3-8312-8e40a8fb55f5" />

### What is the impact of this change?

Customers are aware when there's a new submitter installer. 

### How was this change tested?

Here's the test cases that I manually tested in Maya 2026 on Mac:

| # | Test Case | Steps | Expected Result | Pass? |
|---|-----------|-------|-----------------|-------|
| | **Config GUI — setting visible** | | | |
| 1 | Setting in config GUI | Open VRED → AWS Deadline Cloud → Submit to Deadline Cloud | "Show submitter update notifications" checkbox is visible | YES |
| | **Config disabled — no dialog** | | | |
| 2 | Notification disabled via GUI | Uncheck "Show submitter update notifications" → Apply → close & reopen submitter | No network call, no dialog, submitter opens normally | YES |
| | **Config enabled, no internet — graceful failure** | | | |
| 3 | Re-enable notification via GUI | Check "Show submitter update notifications" → Apply | Setting updated | YES |
| | **Config enabled, internet available, no update** | | | |
| 5 | Current == latest | Restore network, ensure installed version matches manifest | No dialog, submitter opens normally | YES |
| 6 | Current > latest (dev build) | Install a version newer than manifest | No dialog, submitter opens normally | YES |
| | **Config enabled, internet available, update exists** | | | |
| 7 | Current < latest | Install an older version than manifest | Update dialog appears | YES |
| 8 | Dialog content | Inspect the dialog | Shows "VRED", correct current & latest versions | YES |
| 9 | Dialog layout | Resize / check | Min width 400px, text wraps properly | YES |
| 10 | Dialog timing | Observe launch order | Dialog appears before Maya submitter window | YES |
| | **Dialog interactions — Dismiss** | | | |
| 11 | Click "Dismiss" | Click Dismiss button | Dialog closes, submitter opens normally | YES |
| 12 | Close via X | Click X button on dialog | Dialog closes, submitter opens normally | YES |
| | **Dialog interactions — Download** | | | |
| 13 | Click "View release notes" | Click the link | VRED GitHub releases page opens in browser | YES |
| 14 | Click "Download" | Click Download button | Correct installer URL opens in browser | YES |
| 15 | Restart reminder | After Download click | "Application Restart Required" info box appears | YES |
| | **Edge cases** | | | |
| 16 | Non-standard `_version.py` tuple | Modify version tuple | No crash | YES |
| 17 | Click "Don't remind me again" | Will dismiss and also never show the dialog again | No crash | YES |
| 18 | Click "Dismiss" | Does not show the dialog again for the session| No crash | YES | 

### Was this change documented?

This change does not require documentation. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
