### PR TITLE
feat: enable deadline-cloud-v2 conda channel in submitter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 
 dependencies = [
-    "deadline >= 0.55.1,< 0.56",
+    "deadline >= 0.59.0,< 0.60",
 ]
 
 [project.scripts]

--- a/src/deadline/vred_submitter/vred_submitter.py
+++ b/src/deadline/vred_submitter/vred_submitter.py
@@ -250,6 +250,7 @@ class VREDSubmitter:
             parent=self.parent_window,
             f=self.window_flags,
             show_host_requirements_tab=True,
+            use_deadline_cloud_v2_channel=True,
         )
         submitter_dialog.setMinimumSize(
             UIConstants.SUBMITTER_DIALOG_WINDOW_DIMENSIONS[0],


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The VRED submitter currently submits jobs using only the deadline-cloud conda channel. The new deadline-cloud-v2 automated pipeline is live and we need the submitter to use the V2 channel for package resolution.

### What was the solution? (How)
- Pass `use_deadline_cloud_v2_channel=True` to `SubmitJobToDeadlineDialog`, which prepends `deadline-cloud-v2` to the `CondaChannels` parameter.
- Bump `deadline` dependency from `>= 0.55.1, < 0.56` to `>= 0.59.0, < 0.60` (required for the new flag, added in deadline-cloud PR #1211).

### What is the impact of this change?
Jobs submitted from the VRED submitter will request packages from `deadline-cloud-v2` first, falling back to `deadline-cloud`. The existing channel remains as a fallback — no disruption to current users.

### How was this change tested?
- Built installer locally with `hatch run installer:build-installer --platform windows --local-dev`
- Installed on Windows workstation with VRED 2026
- Verified submitter dialog shows `deadline-cloud-v2 deadline-cloud` in Conda Channels field
<img width="1512" height="982" alt="Screenshot 2026-06-22 at 6 14 11 PM" src="https://github.com/user-attachments/assets/1b8c3c0c-17df-4da1-ba7c-aa1ed7c79f75" />


#### Please run the integration tests and paste the results below
N/A — no adaptor logic changed; this is a submitter-only config change.

### Was this change documented?
No documentation changes needed — this is an internal configuration change with no user-facing API change.

### Is this a breaking change?
No. The `use_deadline_cloud_v2_channel` argument is keyword-only with a default of `False` in the upstream `deadline-cloud` library. The dependency bump to `>= 0.59.0` is required but `deadline-cloud` 0.59.0 is already published.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
